### PR TITLE
Append & link support

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -17,6 +17,7 @@ from . import (
     properties,
     ui,
     functions,
+    versioning,
 )
 
 
@@ -36,6 +37,7 @@ def register():
     preferences.register()
     properties.register()
     ui.register()
+    versioning.register()
     operators_register()
 
     preferences.update_sidebar_category(bpy.context.preferences.addons[__package__].preferences, bpy.context)
@@ -64,6 +66,7 @@ def unregister():
     preferences.unregister()
     properties.unregister()
     ui.unregister()
+    versioning.unregister()
     operators_unregister()
 
     # HANDLERS

--- a/operators/convert_shape_keys.py
+++ b/operators/convert_shape_keys.py
@@ -40,7 +40,8 @@ class OBJECT_OT_shape_keys_to_keymesh(bpy.types.Operator):
 
     @classmethod
     def poll(cls, context):
-        return context.active_object and context.active_object.type in ('MESH', 'CURVE', 'LATTICE') and context.active_object.data.shape_keys is not None
+        return (context.active_object and context.active_object.type in ('MESH', 'CURVE', 'LATTICE')
+                and context.active_object.data.shape_keys is not None and context.active_object in context.editable_objects)
 
     # Naming Convention
     def naming_convention(self, key):

--- a/operators/convert_shape_keys.py
+++ b/operators/convert_shape_keys.py
@@ -97,6 +97,8 @@ class OBJECT_OT_shape_keys_to_keymesh(bpy.types.Operator):
             new_block.name = obj.name + "_frame_" + str(frame)
             new_block.use_fake_user = True
             new_block["Keymesh ID"] = obj_km_id
+            block_registry = obj.keymesh.blocks.add()
+            block_registry.block = new_block
 
             # apply_shape_keys
             obj.data = new_block

--- a/operators/frame_picker.py
+++ b/operators/frame_picker.py
@@ -25,11 +25,12 @@ class OBJECT_OT_keymesh_pick_frame(bpy.types.Operator):
         keymesh_block = context.object.data.get("Keymesh Data")
 
         # Keyframe Block
-        if context.scene.keymesh.insert_on_selection:
-            obj["Keymesh Data"] = keymesh_block
-            obj.keyframe_insert(data_path='["Keymesh Data"]', frame=context.scene.frame_current)
+        if obj in context.editable_objects:
+            if context.scene.keymesh.insert_on_selection:
+                obj["Keymesh Data"] = keymesh_block
+                obj.keyframe_insert(data_path='["Keymesh Data"]', frame=context.scene.frame_current)
 
-        bpy.ops.object.mode_set(mode=current_mode)
+            bpy.ops.object.mode_set(mode=current_mode)
         return {'FINISHED'}
 
 

--- a/operators/insert_keyframe.py
+++ b/operators/insert_keyframe.py
@@ -106,8 +106,9 @@ class OBJECT_OT_keymesh_insert(bpy.types.Operator):
         if prefs.enable_edit_mode:
             return is_candidate_object(context)
         else:
-            return is_candidate_object(context) and bpy.context.mode not in [
-                    'EDIT_MESH', 'EDIT_CURVE', 'EDIT_SURFACE', 'EDIT_TEXT', 'EDIT_CURVES', 'EDIT_METABALL', 'EDIT_LATTICE']
+            return (is_candidate_object(context) and context.active_object in context.editable_objects
+                    and bpy.context.mode not in ['EDIT_MESH', 'EDIT_CURVE', 'EDIT_SURFACE', 'EDIT_TEXT',
+                                                 'EDIT_CURVES', 'EDIT_METABALL', 'EDIT_LATTICE'])
 
     def execute(self, context):
         obj = context.active_object

--- a/operators/insert_keyframe.py
+++ b/operators/insert_keyframe.py
@@ -55,6 +55,8 @@ def insert_keymesh_keyframe(context, obj):
         obj.data = new_block
         obj.data.use_fake_user = True
         obj["Keymesh Data"] = block_index
+        block_registry = obj.keymesh.blocks.add()
+        block_registry.block = new_block
 
         # Insert Keyframe
         obj.keyframe_insert(data_path='["Keymesh Data"]',

--- a/operators/purge_unused_data.py
+++ b/operators/purge_unused_data.py
@@ -1,4 +1,5 @@
 import bpy
+from ..functions.object import list_block_users
 from ..functions.handler import update_keymesh
 from ..functions.poll import obj_data_type
 
@@ -57,6 +58,14 @@ class OBJECT_OT_purge_keymesh_data(bpy.types.Operator):
         # purge_unused_blocks
         for block in delete_keymesh_blocks:
             block.use_fake_user = False
+
+            # remove_from_block_registry
+            users = list_block_users(block)
+            for user in users:
+                for index, mesh_ref in enumerate(user.keymesh.blocks):
+                    if mesh_ref.block == block:
+                        user.keymesh.blocks.remove(index)
+
             if block.users == 0:
                 if isinstance(block, bpy.types.Mesh):
                     bpy.data.meshes.remove(block)
@@ -117,6 +126,11 @@ class OBJECT_OT_keymesh_remove(bpy.types.Operator):
                 current_frame = bpy.context.scene.frame_current
                 bpy.context.scene.frame_set(current_frame + 1)
                 bpy.context.scene.frame_set(current_frame)
+
+                # remove_from_block_registry
+                for index, mesh_ref in enumerate(obj.keymesh.blocks):
+                    if mesh_ref.block == block:
+                        obj.keymesh.blocks.remove(index)
 
                 # Purge
                 data_type = obj_data_type(obj)

--- a/operators/purge_unused_data.py
+++ b/operators/purge_unused_data.py
@@ -106,6 +106,10 @@ class OBJECT_OT_keymesh_remove(bpy.types.Operator):
     bl_description = "Removes selected Keymesh block and deletes every keyframe associated with it"
     bl_options = {'REGISTER', 'UNDO'}
 
+    @classmethod
+    def poll(cls, context):
+        return context.active_object in context.editable_objects
+
     def execute(self, context):
         obj = bpy.context.object
         obj_id = obj.get("Keymesh ID", None)

--- a/properties.py
+++ b/properties.py
@@ -5,7 +5,7 @@ import bpy
 
 class KeymeshBlocks(bpy.types.PropertyGroup):
     block: bpy.props.PointerProperty(
-        type = bpy.types.Mesh,
+        type = bpy.types.ID,
     )
 
 
@@ -13,6 +13,7 @@ class OBJECT_PG_keymesh(bpy.types.PropertyGroup):
     # OBJECT-level PROPERTIES
 
     blocks: bpy.props.CollectionProperty(
+        name = "Keymesh Blocks",
         type = KeymeshBlocks,
     )
 

--- a/properties.py
+++ b/properties.py
@@ -3,6 +3,20 @@ import bpy
 
 #### ------------------------------ PROPERTIES ------------------------------ ####
 
+class KeymeshBlocks(bpy.types.PropertyGroup):
+    block: bpy.props.PointerProperty(
+        type = bpy.types.Mesh,
+    )
+
+
+class OBJECT_PG_keymesh(bpy.types.PropertyGroup):
+    # OBJECT-level PROPERTIES
+
+    blocks: bpy.props.CollectionProperty(
+        type = KeymeshBlocks,
+    )
+
+
 class SCENE_PG_keymesh(bpy.types.PropertyGroup):
     # SCENE-level PROPERTIES
 
@@ -42,6 +56,8 @@ class SCENE_PG_keymesh(bpy.types.PropertyGroup):
 #### ------------------------------ REGISTRATION ------------------------------ ####
 
 classes = [
+    KeymeshBlocks,
+    OBJECT_PG_keymesh,
     SCENE_PG_keymesh,
 ]
 
@@ -51,6 +67,7 @@ def register():
 
     # PROPERTY
     bpy.types.Scene.keymesh = bpy.props.PointerProperty(type = SCENE_PG_keymesh)
+    bpy.types.Object.keymesh = bpy.props.PointerProperty(type = OBJECT_PG_keymesh)
 
 def unregister():
     for cls in reversed(classes):
@@ -58,3 +75,4 @@ def unregister():
 
     # PROPERTY
     del bpy.types.Scene.keymesh
+    del bpy.types.Object.keymesh

--- a/ui.py
+++ b/ui.py
@@ -18,6 +18,7 @@ class VIEW3D_PT_keymesh(bpy.types.Panel):
         layout.use_property_decorate = False
 
         scene = context.scene.keymesh
+        obj = context.active_object
 
         # Frame Step
         column = layout.column()
@@ -25,12 +26,14 @@ class VIEW3D_PT_keymesh(bpy.types.Panel):
         row.prop(scene, "frame_skip_count", text="Frame Step")
         row.separator()
         row.prop(scene, "insert_keyframe_after_skip", text="")
+        if obj not in context.editable_objects:
+            row.enabled = False
 
         # Insert Keyframes
         column = layout.column()
         row = column.row(align=False)
         row.alignment = 'EXPAND'
-        if scene.insert_keyframe_after_skip:
+        if scene.insert_keyframe_after_skip and obj in context.editable_objects:
             row.operator("object.keyframe_object_data", text="Insert", icon_value=6).path="BACKWARD"
             row.operator("object.keyframe_object_data", text="", icon='DECORATE_KEYFRAME')
             row.operator("object.keyframe_object_data", text="Insert", icon_value=4).path="FORWARD"

--- a/ui.py
+++ b/ui.py
@@ -79,7 +79,10 @@ class VIEW3D_PT_keymesh_frame_picker(bpy.types.Panel):
         col.operator("object.purge_keymesh_data", text="", icon='TRASH')
 
         # Properties
-        layout.prop(scene, "insert_on_selection", text="Keyframe on Selection")
+        col = layout.column(align=True)
+        col.prop(scene, "insert_on_selection", text="Keyframe on Selection")
+        if not obj in context.editable_objects:
+            col.enabled = False
 
 
 class VIEW3D_PT_keymesh_tools(bpy.types.Panel):
@@ -116,7 +119,7 @@ class VIEW3D_UL_keymesh_blocks(bpy.types.UIList):
         row = col.row(align=True)
 
         # insert_button_icon
-        if context.scene.keymesh.insert_on_selection:
+        if context.scene.keymesh.insert_on_selection and obj in context.editable_objects:
             select_icon = 'PINNED' if block_keymesh_data == obj_keymesh_data else 'UNPINNED'
         else:
             if block_keymesh_data == obj.data.get("Keymesh Data") and block_keymesh_data != obj_keymesh_data:

--- a/versioning.py
+++ b/versioning.py
@@ -1,0 +1,39 @@
+import bpy
+from .functions.poll import obj_data_type
+
+
+#### ------------------------------ FUNCTIONS ------------------------------ ####
+
+@bpy.app.handlers.persistent
+def populate_keymesh_blocks(scene):
+    for obj in bpy.data.objects:
+        # is_not_keymesh_object
+        if obj.get("Keymesh Data") is None:
+            continue
+        obj_keymesh_id = obj.get("Keymesh ID")
+
+        # list_objects_blocks
+        unregistered_blocks = []
+        for block in obj_data_type(obj):
+            if block.get("Keymesh ID") is None:
+                continue
+
+            if block.get("Keymesh ID") == obj_keymesh_id:
+                unregistered_blocks.append(block)
+
+        # register_to_object
+        for block in unregistered_blocks:
+            block_registry = obj.keymesh.blocks.add()
+            block_registry.block = block
+
+
+
+#### ------------------------------ REGISTRATION ------------------------------ ####
+
+def register():
+    # HANDLERS
+    bpy.app.handlers.load_post.append(populate_keymesh_blocks)
+
+def unregister():
+    # HANDLERS
+    bpy.app.handlers.load_post.remove(populate_keymesh_blocks)


### PR DESCRIPTION
Implement #1 

This PR tries to implement append & link support for Keymesh objects by storing references to each block on the object level. Because of how Blender works each dependency will be imported in .blend file when you append or link. But it needs to be tested to see if this will work for copy-pasting and assets.

To-do:
- [x] Purge and remove operators need to remove reference to block from the object.
- [x] Disable operators for linked objects.
- [x] Dynamically define the type of object-data.
- [x] Psuedo-versioning for old Keymesh files.

---
Individual commits contain more information.