### PR TITLE
Sort blocks in Frame Picker by index; allow search, order by name, moving

### DIFF
--- a/operators/convert_shape_keys.py
+++ b/operators/convert_shape_keys.py
@@ -100,6 +100,7 @@ class OBJECT_OT_shape_keys_to_keymesh(bpy.types.Operator):
             new_block["Keymesh ID"] = obj_km_id
             block_registry = obj.keymesh.blocks.add()
             block_registry.block = new_block
+            block_registry.name = new_block.name
 
             # apply_shape_keys
             obj.data = new_block

--- a/operators/frame_picker.py
+++ b/operators/frame_picker.py
@@ -35,34 +35,34 @@ class OBJECT_OT_keymesh_pick_frame(bpy.types.Operator):
         return {'FINISHED'}
 
 
-# class OBJECT_OT_keymesh_block_move(bpy.types.Operator):
-#     bl_idname = "object.keymesh_block_move"
-#     bl_label = "Move Keymesh Block"
-#     bl_description = "Move the active Keymesh block up or down in the frame picker"
-#     bl_options = {'UNDO'}
+class OBJECT_OT_keymesh_block_move(bpy.types.Operator):
+    bl_idname = "object.keymesh_block_move"
+    bl_label = "Move Keymesh Block"
+    bl_description = "Move the active Keymesh block up or down in the frame picker"
+    bl_options = {'UNDO'}
 
-#     direction: bpy.props.EnumProperty(
-#         name = "Direction",
-#         items = [('UP', "", ""),
-#                 ('DOWN', "", ""),],
-#     )
+    direction: bpy.props.EnumProperty(
+        name = "Direction",
+        items = [('UP', "", ""),
+                ('DOWN', "", ""),],
+    )
 
-#     @classmethod
-#     def poll(cls, context):
-#         return True
+    @classmethod
+    def poll(cls, context):
+        return True
 
-#     def execute(self, context):
-#         obj = context.object.data
-#         index = int(obj.keymesh.block_active_index)
+    def execute(self, context):
+        obj = context.object
+        index = int(obj.keymesh.block_active_index)
 
-#         if self.direction == 'UP' and index > 0:
-#             obj.keymesh_blocks.move(index, index - 1)
-#             obj.keymesh.block_active_index -= 1
+        if self.direction == 'UP' and index > 0:
+            obj.keymesh.blocks.move(index, index - 1)
+            obj.keymesh.block_active_index -= 1
 
-#         elif self.direction == 'DOWN' and (index + 1) < len(''): # length_should_be_of_full_list_of_items_in_ui_list
-#             obj.keymesh_blocks.move(index, index + 1)
-#             obj.keymesh.block_active_index += 1
-#         return {'FINISHED'}
+        elif self.direction == 'DOWN' and (index + 1) < len(obj.keymesh.blocks):
+            obj.keymesh.blocks.move(index, index + 1)
+            obj.keymesh.block_active_index += 1
+        return {'FINISHED'}
 
 
 
@@ -70,7 +70,7 @@ class OBJECT_OT_keymesh_pick_frame(bpy.types.Operator):
 
 classes = [
     OBJECT_OT_keymesh_pick_frame,
-    # OBJECT_OT_keymesh_block_move,
+    OBJECT_OT_keymesh_block_move,
 ]
 
 def register():

--- a/operators/frame_picker.py
+++ b/operators/frame_picker.py
@@ -53,15 +53,15 @@ class OBJECT_OT_keymesh_pick_frame(bpy.types.Operator):
 
 #     def execute(self, context):
 #         obj = context.object.data
-#         index = int(context.scene.keymesh_block_active_index)
+#         index = int(obj.keymesh.block_active_index)
 
 #         if self.direction == 'UP' and index > 0:
 #             obj.keymesh_blocks.move(index, index - 1)
-#             context.scene.keymesh_block_active_index -= 1
+#             obj.keymesh.block_active_index -= 1
 
 #         elif self.direction == 'DOWN' and (index + 1) < len(''): # length_should_be_of_full_list_of_items_in_ui_list
 #             obj.keymesh_blocks.move(index, index + 1)
-#             context.scene.keymesh_block_active_index += 1
+#             obj.keymesh.block_active_index += 1
 #         return {'FINISHED'}
 
 

--- a/operators/insert_keyframe.py
+++ b/operators/insert_keyframe.py
@@ -57,6 +57,7 @@ def insert_keymesh_keyframe(context, obj):
         obj["Keymesh Data"] = block_index
         block_registry = obj.keymesh.blocks.add()
         block_registry.block = new_block
+        block_registry.name = new_block.name
 
         # Insert Keyframe
         obj.keyframe_insert(data_path='["Keymesh Data"]',

--- a/properties.py
+++ b/properties.py
@@ -1,11 +1,24 @@
 import bpy
 
 
+#### ------------------------------ FUNCTIONS ------------------------------ ####
+
+def update_block_name(self, context):
+    if self.block:
+        self.block.name = self.name
+
+
+
 #### ------------------------------ PROPERTIES ------------------------------ ####
 
 class KeymeshBlocks(bpy.types.PropertyGroup):
     block: bpy.props.PointerProperty(
+        name = "Block",
         type = bpy.types.ID,
+    )
+    name: bpy.props.StringProperty(
+        name = "Name",
+        update = update_block_name,
     )
 
 
@@ -15,6 +28,10 @@ class OBJECT_PG_keymesh(bpy.types.PropertyGroup):
     blocks: bpy.props.CollectionProperty(
         name = "Keymesh Blocks",
         type = KeymeshBlocks,
+    )
+    block_active_index: bpy.props.IntProperty(
+        name = "Active Block Index",
+        default = -1,
     )
 
 
@@ -40,10 +57,6 @@ class SCENE_PG_keymesh(bpy.types.PropertyGroup):
         name = "Keyframe Keymesh Blocks After Selection",
         description = "Automatically insert keyframe on current frame for Keymesh block when selecting it.",
         default = True,
-    )
-
-    keymesh_block_active_index: bpy.props.IntProperty(
-        default = -1,
     )
 
     def update_properties_from_preferences(self):

--- a/ui.py
+++ b/ui.py
@@ -76,9 +76,9 @@ class VIEW3D_PT_keymesh_frame_picker(bpy.types.Panel):
         col.operator("object.keyframe_object_data", text="", icon='ADD')
         col.operator("object.remove_keymesh_block", text="", icon='REMOVE')
         col.separator()
-        # col.operator("object.keymesh_block_move", text="", icon='TRIA_UP').type = 'UP'
-        # col.operator("object.keymesh_block_move", text="", icon='TRIA_DOWN').type = 'DOWN'
-        # col.separator()
+        col.operator("object.keymesh_block_move", text="", icon='TRIA_UP').direction='UP'
+        col.operator("object.keymesh_block_move", text="", icon='TRIA_DOWN').direction='DOWN'
+        col.separator()
         col.operator("object.purge_keymesh_data", text="", icon='TRASH')
 
         # Properties

--- a/ui.py
+++ b/ui.py
@@ -75,11 +75,10 @@ class VIEW3D_PT_keymesh_frame_picker(bpy.types.Panel):
         col = row.column(align=True)
         col.operator("object.keyframe_object_data", text="", icon='ADD')
         col.operator("object.remove_keymesh_block", text="", icon='REMOVE')
+        col.operator("object.purge_keymesh_data", text="", icon='TRASH')
         col.separator()
         col.operator("object.keymesh_block_move", text="", icon='TRIA_UP').direction='UP'
         col.operator("object.keymesh_block_move", text="", icon='TRIA_DOWN').direction='DOWN'
-        col.separator()
-        col.operator("object.purge_keymesh_data", text="", icon='TRASH')
 
         # Properties
         col = layout.column(align=True)


### PR DESCRIPTION
Because now blocks are directly stored on objects as references `keymesh.blocks` collection can be used in Frame Pickers UI list instead of filtered meshes (that means filtering can be completely removed). Because `keymesh.blocks` has internal index it means blocks in UI list can be ordered by that index instead of name, as they were before.

- But ordering by name is still desired, so this PR also adds `name` property to `KeymeshBlocks` PropertyGroup. Now UI list is displaying that name property, instead of the mesh name directly. The downside is that it needs `update_block_name` function on an update to make mesh names match `KeymeshBlocks` name, but the upside is that since UI list can optionally sort by name, and allows searching by it too.

- Since ordering is done by index now, we can also have operator that changes that index to reorder items in Frame Picker UI list. Two buttons are placed in the UI, similar to built-in UI lists in Blender.

---

Other changes in this PR:
- `block_active_index` is moved from scene to object properties, where it should be
- "Purge Unused Keymesh BLocks" operator is moved up above move arrows
- When new blocks are added to the registry `name` property is set based on blocks name
- Little bit of formatting