### PR TITLE
Move object and block properties inside 'keymesh' PropertyGroup

### DIFF
--- a/functions/handler.py
+++ b/functions/handler.py
@@ -8,11 +8,11 @@ from .poll import obj_data_type
 def update_keymesh(scene):
     for obj in bpy.data.objects:
         # is_not_keymesh_object
-        if obj.get("Keymesh Data") is None:
+        if obj.keymesh.get("Keymesh Data") is None:
             continue
 
         obj_keymesh_id = obj.keymesh["ID"]
-        obj_keymesh_data = obj["Keymesh Data"]
+        obj_keymesh_data = obj.keymesh["Keymesh Data"]
 
         final_block = None
         for block in obj_data_type(obj):

--- a/functions/handler.py
+++ b/functions/handler.py
@@ -17,10 +17,10 @@ def update_keymesh(scene):
         final_block = None
         for block in obj_data_type(obj):
             # is_not_keymesh_block
-            if block.get("Keymesh ID") is None:
+            if block.keymesh.get("ID") is None:
                 continue
 
-            block_km_id = block["Keymesh ID"]
+            block_km_id = block.keymesh["ID"]
             block_km_data = block["Keymesh Data"]
 
             # is_not_objects_block

--- a/functions/handler.py
+++ b/functions/handler.py
@@ -21,7 +21,7 @@ def update_keymesh(scene):
                 continue
 
             block_km_id = block.keymesh["ID"]
-            block_km_data = block["Keymesh Data"]
+            block_km_data = block.keymesh["Data"]
 
             # is_not_objects_block
             if block_km_id != obj_keymesh_id:

--- a/functions/handler.py
+++ b/functions/handler.py
@@ -11,7 +11,7 @@ def update_keymesh(scene):
         if obj.get("Keymesh Data") is None:
             continue
 
-        obj_keymesh_id = obj["Keymesh ID"]
+        obj_keymesh_id = obj.keymesh["Keymesh ID"]
         obj_keymesh_data = obj["Keymesh Data"]
 
         final_block = None
@@ -41,7 +41,7 @@ def update_keymesh(scene):
 # def frame_handler(dummy):
 #     objects = bpy.data.objects
 #     for obj in objects:
-#         if "Keymesh Data" and "Keymesh ID" in obj:
+#         if "Keymesh Data" and "Keymesh ID" in obj.keymesh:
 #             bpy.app.handlers.frame_change_post.remove(update_keymesh)
 #             bpy.app.handlers.frame_change_post.append(update_keymesh)
 #             break

--- a/functions/handler.py
+++ b/functions/handler.py
@@ -11,7 +11,7 @@ def update_keymesh(scene):
         if obj.get("Keymesh Data") is None:
             continue
 
-        obj_keymesh_id = obj.keymesh["Keymesh ID"]
+        obj_keymesh_id = obj.keymesh["ID"]
         obj_keymesh_data = obj["Keymesh Data"]
 
         final_block = None
@@ -41,7 +41,7 @@ def update_keymesh(scene):
 # def frame_handler(dummy):
 #     objects = bpy.data.objects
 #     for obj in objects:
-#         if "Keymesh Data" and "Keymesh ID" in obj.keymesh:
+#         if "Keymesh Data" and "ID" in obj.keymesh:
 #             bpy.app.handlers.frame_change_post.remove(update_keymesh)
 #             bpy.app.handlers.frame_change_post.append(update_keymesh)
 #             break

--- a/functions/object.py
+++ b/functions/object.py
@@ -24,7 +24,7 @@ def get_next_keymesh_index(context, obj):
     if obj.get("Keymesh Data") is None:
         return 0
     else:
-        obj_keymesh_id = obj.get("Keymesh ID")
+        obj_keymesh_id = obj.keymesh.get("Keymesh ID")
         obj = context.active_object
 
         # list_keymesh_blocks_of_the_object
@@ -48,8 +48,8 @@ def get_next_keymesh_index(context, obj):
 def list_block_users(block):
     users = []
     for obj in bpy.data.objects:
-        if obj.get("Keymesh ID", None):
-            if block.get("Keymesh ID") == obj.get("Keymesh ID"):
+        if obj.keymesh.get("Keymesh ID", None):
+            if block.get("Keymesh ID") == obj.keymesh.get("Keymesh ID"):
                 users.append(obj)
 
     return users

--- a/functions/object.py
+++ b/functions/object.py
@@ -21,7 +21,7 @@ def new_object_id(context):
 def get_next_keymesh_index(context, obj):
     """Get the appropriate index for the newly created Keymesh block"""
 
-    if obj.get("Keymesh Data") is None:
+    if obj.keymesh.get("Keymesh Data") is None:
         return 0
     else:
         obj_keymesh_id = obj.keymesh.get("ID")

--- a/functions/object.py
+++ b/functions/object.py
@@ -10,8 +10,8 @@ def new_object_id(context):
     max_id = 0
     obj = context.object
     for item in obj_data_type(obj):
-        if item.get("Keymesh ID") is not None:
-            obj_keymesh_id = item["Keymesh ID"]
+        if item.keymesh.get("ID") is not None:
+            obj_keymesh_id = item.keymesh["ID"]
             if obj_keymesh_id > max_id:
                 max_id = obj_keymesh_id
 
@@ -30,7 +30,7 @@ def get_next_keymesh_index(context, obj):
         # list_keymesh_blocks_of_the_object
         keymesh_blocks = []
         for block in obj_data_type(obj):
-            if block.get("Keymesh ID") == obj_keymesh_id:
+            if block.keymesh.get("ID") == obj_keymesh_id:
                 keymesh_blocks.append(block)
 
         # find_the_largest_value_in_the_list
@@ -49,7 +49,7 @@ def list_block_users(block):
     users = []
     for obj in bpy.data.objects:
         if obj.keymesh.get("ID", None):
-            if block.get("Keymesh ID") == obj.keymesh.get("ID"):
+            if block.keymesh.get("ID") == obj.keymesh.get("ID"):
                 users.append(obj)
 
     return users

--- a/functions/object.py
+++ b/functions/object.py
@@ -36,7 +36,7 @@ def get_next_keymesh_index(context, obj):
         # find_the_largest_value_in_the_list
         largest_value = None
         for block in keymesh_blocks:
-            block_keymesh_data = block.get("Keymesh Data")
+            block_keymesh_data = block.keymesh.get("Data")
             if block_keymesh_data is not None:
                 if largest_value is None or block_keymesh_data > largest_value:
                     largest_value = block_keymesh_data

--- a/functions/object.py
+++ b/functions/object.py
@@ -10,8 +10,8 @@ def new_object_id(context):
     max_id = 0
     obj = context.object
     for item in obj_data_type(obj):
-        if item.get("ID") is not None:
-            obj_keymesh_id = item["ID"]
+        if item.get("Keymesh ID") is not None:
+            obj_keymesh_id = item["Keymesh ID"]
             if obj_keymesh_id > max_id:
                 max_id = obj_keymesh_id
 

--- a/functions/object.py
+++ b/functions/object.py
@@ -10,8 +10,8 @@ def new_object_id(context):
     max_id = 0
     obj = context.object
     for item in obj_data_type(obj):
-        if item.get("Keymesh ID") is not None:
-            obj_keymesh_id = item["Keymesh ID"]
+        if item.get("ID") is not None:
+            obj_keymesh_id = item["ID"]
             if obj_keymesh_id > max_id:
                 max_id = obj_keymesh_id
 
@@ -24,7 +24,7 @@ def get_next_keymesh_index(context, obj):
     if obj.get("Keymesh Data") is None:
         return 0
     else:
-        obj_keymesh_id = obj.keymesh.get("Keymesh ID")
+        obj_keymesh_id = obj.keymesh.get("ID")
         obj = context.active_object
 
         # list_keymesh_blocks_of_the_object
@@ -48,8 +48,8 @@ def get_next_keymesh_index(context, obj):
 def list_block_users(block):
     users = []
     for obj in bpy.data.objects:
-        if obj.keymesh.get("Keymesh ID", None):
-            if block.get("Keymesh ID") == obj.keymesh.get("Keymesh ID"):
+        if obj.keymesh.get("ID", None):
+            if block.get("Keymesh ID") == obj.keymesh.get("ID"):
                 users.append(obj)
 
     return users

--- a/functions/timeline.py
+++ b/functions/timeline.py
@@ -87,7 +87,7 @@ def get_next_keymesh_block(context, obj, direction):
                     break
 
         for mesh in bpy.data.meshes:
-            if mesh.get("Keymesh ID", None) and mesh.get("Keymesh ID", None) == obj_id:
+            if mesh.keymesh.get("ID", None) and mesh.get("ID", None) == obj_id:
                 if mesh.get("Keymesh Data", None) == next_value:
                     next_keymesh_block = mesh
 

--- a/functions/timeline.py
+++ b/functions/timeline.py
@@ -9,7 +9,7 @@ def get_keymesh_fcurve(context, obj):
     if obj is None:
         obj = context.active_object
 
-    if obj.keymesh.get("Keymesh ID") is not None:
+    if obj.keymesh.get("ID") is not None:
         if obj.animation_data is not None:
             for f in obj.animation_data.action.fcurves:
                 if f.data_path == '["Keymesh Data"]':
@@ -63,12 +63,12 @@ def get_next_keymesh_block(context, obj, direction):
     if obj is None:
         obj = context.active_object
 
-    obj_id = obj.keymesh.get("Keymesh ID", None)
+    obj_id = obj.keymesh.get("ID", None)
     next_keyframe = None
     next_value = None
     next_keymesh_block = None
 
-    if obj.keymesh.get("Keymesh ID") is not None:
+    if obj.keymesh.get("ID") is not None:
         current_frame = context.scene.frame_current
         fcurve = get_keymesh_fcurve(context, obj)
         keyframe_points = fcurve.keyframe_points

--- a/functions/timeline.py
+++ b/functions/timeline.py
@@ -9,7 +9,7 @@ def get_keymesh_fcurve(context, obj):
     if obj is None:
         obj = context.active_object
 
-    if obj.get("Keymesh ID") is not None:
+    if obj.keymesh.get("Keymesh ID") is not None:
         if obj.animation_data is not None:
             for f in obj.animation_data.action.fcurves:
                 if f.data_path == '["Keymesh Data"]':
@@ -63,12 +63,12 @@ def get_next_keymesh_block(context, obj, direction):
     if obj is None:
         obj = context.active_object
 
-    obj_id = obj.get("Keymesh ID", None)
+    obj_id = obj.keymesh.get("Keymesh ID", None)
     next_keyframe = None
     next_value = None
     next_keymesh_block = None
 
-    if obj.get("Keymesh ID") is not None:
+    if obj.keymesh.get("Keymesh ID") is not None:
         current_frame = context.scene.frame_current
         fcurve = get_keymesh_fcurve(context, obj)
         keyframe_points = fcurve.keyframe_points

--- a/functions/timeline.py
+++ b/functions/timeline.py
@@ -12,7 +12,7 @@ def get_keymesh_fcurve(context, obj):
     if obj.keymesh.get("ID") is not None:
         if obj.animation_data is not None:
             for f in obj.animation_data.action.fcurves:
-                if f.data_path == '["Keymesh Data"]':
+                if f.data_path == 'keymesh["Keymesh Data"]':
                     fcurve = f
 
         # alternative_way
@@ -21,7 +21,7 @@ def get_keymesh_fcurve(context, obj):
         #         fcurves = action.fcurves
         #         if fcurves is not None:
         #             for f in fcurves:
-        #                 if f.data_path == '["Keymesh Data"]':
+        #                 if f.data_path == 'keymesh["Keymesh Data"]':
         #                     fcurve = f
 
     return fcurve

--- a/functions/timeline.py
+++ b/functions/timeline.py
@@ -46,7 +46,7 @@ def keymesh_block_usage_count(self, context, block):
     """Returns number of uses (keyframes) for each Keymesh block for object"""
 
     obj = context.object
-    value = block["Keymesh Data"]
+    value = block.keymesh["Data"]
     count = 0
 
     fcurve = get_keymesh_fcurve(context, obj)
@@ -88,7 +88,7 @@ def get_next_keymesh_block(context, obj, direction):
 
         for mesh in bpy.data.meshes:
             if mesh.keymesh.get("ID", None) and mesh.get("ID", None) == obj_id:
-                if mesh.get("Keymesh Data", None) == next_value:
+                if mesh.keymesh.get("Data", None) == next_value:
                     next_keymesh_block = mesh
 
     return next_keyframe, next_keymesh_block

--- a/operators/convert_shape_keys.py
+++ b/operators/convert_shape_keys.py
@@ -117,19 +117,19 @@ class OBJECT_OT_shape_keys_to_keymesh(bpy.types.Operator):
                     match = next((block for block in bpy.data.meshes if block.get("shape_key_value") == name), None)
                     match_id = match.keymesh.get("Data")
                     bpy.data.meshes.remove(new_block)
-                    obj["Keymesh Data"] = match_id
+                    obj.keymesh["Keymesh Data"] = match_id
                 else:
                     new_block["shape_key_value"] = name
-                    obj["Keymesh Data"] = block_index
+                    obj.keymesh["Keymesh Data"] = block_index
             else:
-                obj["Keymesh Data"] = block_index
+                obj.keymesh["Keymesh Data"] = block_index
 
             # animate_keymesh_data
             if current_values != initial_values:
-                obj.keyframe_insert(data_path='["Keymesh Data"]', frame=context.scene.frame_current)
+                obj.keyframe_insert(data_path='keymesh["Keymesh Data"]', frame=context.scene.frame_current)
                 initial_values = current_values
 
-        fcurve = obj.animation_data.action.fcurves.find('["Keymesh Data"]')
+        fcurve = obj.animation_data.action.fcurves.find('keymesh["Keymesh Data"]')
         for keyframe_point in fcurve.keyframe_points:
             keyframe_point.interpolation = 'CONSTANT'
 
@@ -240,7 +240,7 @@ class OBJECT_OT_keymesh_to_objects(bpy.types.Operator):
         move_axis_index = 'XYZ'.index(self.move_axis)
 
         # Get frame_start and end by keymesh data_block names or custom properties
-        animated_frames = [int(keyframe.co.x) for fcurve in obj.animation_data.action.fcurves for keyframe in fcurve.keyframe_points if fcurve.data_path == f'["Keymesh Data"]']
+        animated_frames = [int(keyframe.co.x) for fcurve in obj.animation_data.action.fcurves for keyframe in fcurve.keyframe_points if fcurve.data_path == f'keymesh["Keymesh Data"]']
         frame_start = min(animated_frames)
         frame_end = max(animated_frames)
 
@@ -250,7 +250,7 @@ class OBJECT_OT_keymesh_to_objects(bpy.types.Operator):
         prev_obj = None
         for frame in range(frame_start, frame_end + 1):
             context.scene.frame_set(frame)
-            current_value = obj["Keymesh Data"]
+            current_value = obj.keymesh["Keymesh Data"]
 
             if current_value != previous_value:
                 # Duplicate Object
@@ -258,7 +258,7 @@ class OBJECT_OT_keymesh_to_objects(bpy.types.Operator):
                 dup_obj.name = obj.name + "_frame_" + str(frame)
                 dup_obj.animation_data_clear()
                 context.collection.objects.link(dup_obj)
-                del dup_obj["Keymesh Data"]
+                del dup_obj.keymesh["Keymesh Data"]
                 del dup_obj.keymesh["ID"]
 
                 dup_data = obj.data.copy()

--- a/operators/convert_shape_keys.py
+++ b/operators/convert_shape_keys.py
@@ -97,7 +97,7 @@ class OBJECT_OT_shape_keys_to_keymesh(bpy.types.Operator):
             new_block = original_data.copy()
             new_block.name = obj.name + "_frame_" + str(frame)
             new_block.use_fake_user = True
-            new_block["Keymesh ID"] = obj_km_id
+            new_block.keymesh["ID"] = obj_km_id
             block_registry = obj.keymesh.blocks.add()
             block_registry.block = new_block
             block_registry.name = new_block.name
@@ -113,7 +113,7 @@ class OBJECT_OT_shape_keys_to_keymesh(bpy.types.Operator):
 
             # delete_duplicates
             if self.delete_duplicates:
-                if any(block.get("shape_key_value") == name for block in bpy.data.meshes if block.get("Keymesh ID") == obj_km_id):
+                if any(block.get("shape_key_value") == name for block in bpy.data.meshes if block.keymesh.get("ID") == obj_km_id):
                     match = next((block for block in bpy.data.meshes if block.get("shape_key_value") == name), None)
                     match_id = match.get("Keymesh Data")
                     bpy.data.meshes.remove(new_block)
@@ -265,7 +265,7 @@ class OBJECT_OT_keymesh_to_objects(bpy.types.Operator):
                 dup_data.name + obj.data.name + "_frame_" + str(frame)
                 dup_obj.data = dup_data
                 del dup_data["Keymesh Data"]
-                del dup_data["Keymesh ID"]
+                del dup_data.keymesh["ID"]
 
                 # Move to Collection
                 duplicates_collection.objects.link(dup_obj)

--- a/operators/convert_shape_keys.py
+++ b/operators/convert_shape_keys.py
@@ -81,11 +81,11 @@ class OBJECT_OT_shape_keys_to_keymesh(bpy.types.Operator):
             backup.hide_viewport = True
 
         # Assign Keymesh ID Property
-        if obj.get("Keymesh ID") is None:
-            obj["Keymesh ID"] = new_object_id(context)
+        if obj.keymesh.get("Keymesh ID") is None:
+            obj.keymesh["Keymesh ID"] = new_object_id(context)
             if prefs.backup_original_data:
                 original_data.use_fake_user = True
-        obj_km_id = obj["Keymesh ID"]
+        obj_km_id = obj.keymesh["Keymesh ID"]
 
         initial_values = [key.value for key in shape_keys.key_blocks]
         for frame in range(frame_start, frame_end + 1):
@@ -213,7 +213,7 @@ class OBJECT_OT_keymesh_to_objects(bpy.types.Operator):
 
     @classmethod
     def poll(cls, context):
-        return context.active_object is not None and context.active_object.get("Keymesh ID")
+        return context.active_object is not None and context.active_object.keymesh.get("Keymesh ID")
 
     def invoke(self, context, event):
         wm = context.window_manager
@@ -259,7 +259,7 @@ class OBJECT_OT_keymesh_to_objects(bpy.types.Operator):
                 dup_obj.animation_data_clear()
                 context.collection.objects.link(dup_obj)
                 del dup_obj["Keymesh Data"]
-                del dup_obj["Keymesh ID"]
+                del dup_obj.keymesh["Keymesh ID"]
 
                 dup_data = obj.data.copy()
                 dup_data.name + obj.data.name + "_frame_" + str(frame)

--- a/operators/convert_shape_keys.py
+++ b/operators/convert_shape_keys.py
@@ -109,13 +109,13 @@ class OBJECT_OT_shape_keys_to_keymesh(bpy.types.Operator):
 
             # Assign Keymesh Data
             block_index = get_next_keymesh_index(context, obj)
-            new_block["Keymesh Data"] = block_index
+            new_block.keymesh["Data"] = block_index
 
             # delete_duplicates
             if self.delete_duplicates:
                 if any(block.get("shape_key_value") == name for block in bpy.data.meshes if block.keymesh.get("ID") == obj_km_id):
                     match = next((block for block in bpy.data.meshes if block.get("shape_key_value") == name), None)
-                    match_id = match.get("Keymesh Data")
+                    match_id = match.keymesh.get("Data")
                     bpy.data.meshes.remove(new_block)
                     obj["Keymesh Data"] = match_id
                 else:
@@ -264,7 +264,7 @@ class OBJECT_OT_keymesh_to_objects(bpy.types.Operator):
                 dup_data = obj.data.copy()
                 dup_data.name + obj.data.name + "_frame_" + str(frame)
                 dup_obj.data = dup_data
-                del dup_data["Keymesh Data"]
+                del dup_data.keymesh["Data"]
                 del dup_data.keymesh["ID"]
 
                 # Move to Collection

--- a/operators/convert_shape_keys.py
+++ b/operators/convert_shape_keys.py
@@ -81,11 +81,11 @@ class OBJECT_OT_shape_keys_to_keymesh(bpy.types.Operator):
             backup.hide_viewport = True
 
         # Assign Keymesh ID Property
-        if obj.keymesh.get("Keymesh ID") is None:
-            obj.keymesh["Keymesh ID"] = new_object_id(context)
+        if obj.keymesh.get("ID") is None:
+            obj.keymesh["ID"] = new_object_id(context)
             if prefs.backup_original_data:
                 original_data.use_fake_user = True
-        obj_km_id = obj.keymesh["Keymesh ID"]
+        obj_km_id = obj.keymesh["ID"]
 
         initial_values = [key.value for key in shape_keys.key_blocks]
         for frame in range(frame_start, frame_end + 1):
@@ -213,7 +213,7 @@ class OBJECT_OT_keymesh_to_objects(bpy.types.Operator):
 
     @classmethod
     def poll(cls, context):
-        return context.active_object is not None and context.active_object.keymesh.get("Keymesh ID")
+        return context.active_object is not None and context.active_object.keymesh.get("ID")
 
     def invoke(self, context, event):
         wm = context.window_manager
@@ -259,7 +259,7 @@ class OBJECT_OT_keymesh_to_objects(bpy.types.Operator):
                 dup_obj.animation_data_clear()
                 context.collection.objects.link(dup_obj)
                 del dup_obj["Keymesh Data"]
-                del dup_obj.keymesh["Keymesh ID"]
+                del dup_obj.keymesh["ID"]
 
                 dup_data = obj.data.copy()
                 dup_data.name + obj.data.name + "_frame_" + str(frame)

--- a/operators/frame_picker.py
+++ b/operators/frame_picker.py
@@ -28,8 +28,8 @@ class OBJECT_OT_keymesh_pick_frame(bpy.types.Operator):
         # Keyframe Block
         if obj in context.editable_objects:
             if scene.keymesh.insert_on_selection:
-                obj["Keymesh Data"] = keymesh_block
-                obj.keyframe_insert(data_path='["Keymesh Data"]', frame=scene.frame_current)
+                obj.keymesh["Keymesh Data"] = keymesh_block
+                obj.keyframe_insert(data_path='keymesh["Keymesh Data"]', frame=scene.frame_current)
 
             bpy.ops.object.mode_set(mode=current_mode)
         return {'FINISHED'}

--- a/operators/frame_picker.py
+++ b/operators/frame_picker.py
@@ -23,7 +23,7 @@ class OBJECT_OT_keymesh_pick_frame(bpy.types.Operator):
 
         # assign_keymesh_block_to_object
         obj.data = data_type[self.keymesh_index]
-        keymesh_block = context.object.data.get("Keymesh Data")
+        keymesh_block = context.object.data.keymesh.get("Data")
 
         # Keyframe Block
         if obj in context.editable_objects:

--- a/operators/insert_keyframe.py
+++ b/operators/insert_keyframe.py
@@ -25,11 +25,11 @@ def insert_keymesh_keyframe(context, obj):
 
 
         # Assign Keymesh ID
-        if obj.keymesh.get("Keymesh ID") is None:
+        if obj.keymesh.get("ID") is None:
             if prefs.backup_original_data:
                 obj.data.use_fake_user = True
-            obj.keymesh["Keymesh ID"] = new_object_id(context)
-        obj_keymesh_id = obj.keymesh["Keymesh ID"]
+            obj.keymesh["ID"] = new_object_id(context)
+        obj_keymesh_id = obj.keymesh["ID"]
 
         # Get Block Index
         block_index = get_next_keymesh_index(context, obj)
@@ -123,7 +123,7 @@ class OBJECT_OT_keymesh_insert(bpy.types.Operator):
 
             else:
                 # when_forwarding_first_time
-                if obj.keymesh.get("Keymesh ID") is None:
+                if obj.keymesh.get("ID") is None:
                     insert_keymesh_keyframe(context, obj)
                     return {'FINISHED'}
                 

--- a/operators/insert_keyframe.py
+++ b/operators/insert_keyframe.py
@@ -54,17 +54,17 @@ def insert_keymesh_keyframe(context, obj):
         # Assign New Block to Object
         obj.data = new_block
         obj.data.use_fake_user = True
-        obj["Keymesh Data"] = block_index
+        obj.keymesh["Keymesh Data"] = block_index
         block_registry = obj.keymesh.blocks.add()
         block_registry.block = new_block
         block_registry.name = new_block.name
 
         # Insert Keyframe
-        obj.keyframe_insert(data_path='["Keymesh Data"]',
+        obj.keyframe_insert(data_path='keymesh["Keymesh Data"]',
                             frame=context.scene.frame_current)
 
         for fcurve in obj.animation_data.action.fcurves:
-            if fcurve.data_path == '["Keymesh Data"]':
+            if fcurve.data_path == 'keymesh["Keymesh Data"]':
                 for kf in fcurve.keyframe_points:
                     kf.interpolation = 'CONSTANT'
 

--- a/operators/insert_keyframe.py
+++ b/operators/insert_keyframe.py
@@ -48,7 +48,7 @@ def insert_keymesh_keyframe(context, obj):
             new_block = obj.data.copy()
 
         new_block.name = block_name
-        new_block["Keymesh ID"] = obj_keymesh_id
+        new_block.keymesh["ID"] = obj_keymesh_id
         new_block["Keymesh Data"] = block_index
 
         # Assign New Block to Object

--- a/operators/insert_keyframe.py
+++ b/operators/insert_keyframe.py
@@ -25,11 +25,11 @@ def insert_keymesh_keyframe(context, obj):
 
 
         # Assign Keymesh ID
-        if obj.get("Keymesh ID") is None:
+        if obj.keymesh.get("Keymesh ID") is None:
             if prefs.backup_original_data:
                 obj.data.use_fake_user = True
-            obj["Keymesh ID"] = new_object_id(context)
-        obj_keymesh_id = obj["Keymesh ID"]
+            obj.keymesh["Keymesh ID"] = new_object_id(context)
+        obj_keymesh_id = obj.keymesh["Keymesh ID"]
 
         # Get Block Index
         block_index = get_next_keymesh_index(context, obj)
@@ -123,7 +123,7 @@ class OBJECT_OT_keymesh_insert(bpy.types.Operator):
 
             else:
                 # when_forwarding_first_time
-                if obj.get("Keymesh ID") is None:
+                if obj.keymesh.get("Keymesh ID") is None:
                     insert_keymesh_keyframe(context, obj)
                     return {'FINISHED'}
                 

--- a/operators/insert_keyframe.py
+++ b/operators/insert_keyframe.py
@@ -49,7 +49,7 @@ def insert_keymesh_keyframe(context, obj):
 
         new_block.name = block_name
         new_block.keymesh["ID"] = obj_keymesh_id
-        new_block["Keymesh Data"] = block_index
+        new_block.keymesh["Data"] = block_index
 
         # Assign New Block to Object
         obj.data = new_block

--- a/operators/purge_unused_data.py
+++ b/operators/purge_unused_data.py
@@ -54,7 +54,7 @@ class OBJECT_OT_purge_keymesh_data(bpy.types.Operator):
                         delete_keymesh_blocks.append(block)
                         continue
 
-                    block_keymesh_data = block.get("Keymesh Data")
+                    block_keymesh_data = block.keymesh.get("Data")
                     if block_keymesh_data not in used_keymesh_blocks[block_keymesh_id]:
                         delete_keymesh_blocks.append(block)
                         continue
@@ -70,7 +70,7 @@ class OBJECT_OT_purge_keymesh_data(bpy.types.Operator):
                 if block_keymesh_id != obj.keymesh.get("ID"):
                     continue
 
-                block_keymesh_data = block.get("Keymesh Data")
+                block_keymesh_data = block.keymesh.get("Data")
                 if block_keymesh_data not in used_keymesh_blocks[block_keymesh_id]:
                     delete_keymesh_blocks.append(block)
                     continue
@@ -150,7 +150,7 @@ class OBJECT_OT_keymesh_remove(bpy.types.Operator):
         obj_id = obj.keymesh.get("ID", None)
         if obj and obj_id is not None:
             block = obj.data
-            block_keymesh_data = block.get("Keymesh Data")
+            block_keymesh_data = block.keymesh.get("Data")
 
             # Remove Keyframes
             fcurve = get_keymesh_fcurve(context, obj)

--- a/operators/purge_unused_data.py
+++ b/operators/purge_unused_data.py
@@ -46,10 +46,10 @@ class OBJECT_OT_purge_keymesh_data(bpy.types.Operator):
             for data_collection in [bpy.data.meshes, bpy.data.curves, bpy.data.hair_curves, bpy.data.metaballs, bpy.data.volumes,
                                     bpy.data.lattices, bpy.data.lights, bpy.data.lightprobes, bpy.data.cameras, bpy.data.speakers]:
                 for block in data_collection:
-                    if block.get("Keymesh ID") is None:
+                    if block.keymesh.get("ID") is None:
                         continue
 
-                    block_keymesh_id = block.get("Keymesh ID")
+                    block_keymesh_id = block.keymesh.get("ID")
                     if block_keymesh_id not in used_keymesh_blocks:
                         delete_keymesh_blocks.append(block)
                         continue
@@ -63,10 +63,10 @@ class OBJECT_OT_purge_keymesh_data(bpy.types.Operator):
         else:
             obj = context.active_object
             for block in obj_data_type(obj):
-                if block.get("Keymesh ID") is None:
+                if block.keymesh.get("ID") is None:
                     continue
 
-                block_keymesh_id = block.get("Keymesh ID")
+                block_keymesh_id = block.keymesh.get("ID")
                 if block_keymesh_id != obj.keymesh.get("ID"):
                     continue
 

--- a/operators/purge_unused_data.py
+++ b/operators/purge_unused_data.py
@@ -27,10 +27,10 @@ class OBJECT_OT_purge_keymesh_data(bpy.types.Operator):
         used_keymesh_blocks = {}
         objects = bpy.data.objects if self.all else [context.active_object]
         for obj in objects:
-            if obj.keymesh.get("Keymesh ID") is None:
+            if obj.keymesh.get("ID") is None:
                 continue
 
-            obj_keymesh_id = obj.keymesh.get("Keymesh ID")
+            obj_keymesh_id = obj.keymesh.get("ID")
             used_keymesh_blocks[obj_keymesh_id] = []
 
             fcurve = get_keymesh_fcurve(context, obj)
@@ -67,7 +67,7 @@ class OBJECT_OT_purge_keymesh_data(bpy.types.Operator):
                     continue
 
                 block_keymesh_id = block.get("Keymesh ID")
-                if block_keymesh_id != obj.keymesh.get("Keymesh ID"):
+                if block_keymesh_id != obj.keymesh.get("ID"):
                     continue
 
                 block_keymesh_data = block.get("Keymesh Data")
@@ -147,7 +147,7 @@ class OBJECT_OT_keymesh_remove(bpy.types.Operator):
 
     def execute(self, context):
         obj = context.active_object
-        obj_id = obj.keymesh.get("Keymesh ID", None)
+        obj_id = obj.keymesh.get("ID", None)
         if obj and obj_id is not None:
             block = obj.data
             block_keymesh_data = block.get("Keymesh Data")

--- a/operators/purge_unused_data.py
+++ b/operators/purge_unused_data.py
@@ -27,10 +27,10 @@ class OBJECT_OT_purge_keymesh_data(bpy.types.Operator):
         used_keymesh_blocks = {}
         objects = bpy.data.objects if self.all else [context.active_object]
         for obj in objects:
-            if obj.get("Keymesh ID") is None:
+            if obj.keymesh.get("Keymesh ID") is None:
                 continue
 
-            obj_keymesh_id = obj.get("Keymesh ID")
+            obj_keymesh_id = obj.keymesh.get("Keymesh ID")
             used_keymesh_blocks[obj_keymesh_id] = []
 
             fcurve = get_keymesh_fcurve(context, obj)
@@ -67,7 +67,7 @@ class OBJECT_OT_purge_keymesh_data(bpy.types.Operator):
                     continue
 
                 block_keymesh_id = block.get("Keymesh ID")
-                if block_keymesh_id != obj.get("Keymesh ID"):
+                if block_keymesh_id != obj.keymesh.get("Keymesh ID"):
                     continue
 
                 block_keymesh_data = block.get("Keymesh Data")
@@ -147,7 +147,7 @@ class OBJECT_OT_keymesh_remove(bpy.types.Operator):
 
     def execute(self, context):
         obj = context.active_object
-        obj_id = obj.get("Keymesh ID", None)
+        obj_id = obj.keymesh.get("Keymesh ID", None)
         if obj and obj_id is not None:
             block = obj.data
             block_keymesh_data = block.get("Keymesh Data")

--- a/properties.py
+++ b/properties.py
@@ -36,6 +36,7 @@ class OBJECT_PG_keymesh(bpy.types.PropertyGroup):
 
 
 class DATA_PG_keymesh(bpy.types.PropertyGroup):
+    # DATA-level PROPERTIES
     pass
 
 

--- a/properties.py
+++ b/properties.py
@@ -35,6 +35,10 @@ class OBJECT_PG_keymesh(bpy.types.PropertyGroup):
     )
 
 
+class DATA_PG_keymesh(bpy.types.PropertyGroup):
+    pass
+
+
 class SCENE_PG_keymesh(bpy.types.PropertyGroup):
     # SCENE-level PROPERTIES
 
@@ -72,6 +76,7 @@ class SCENE_PG_keymesh(bpy.types.PropertyGroup):
 classes = [
     KeymeshBlocks,
     OBJECT_PG_keymesh,
+    DATA_PG_keymesh,
     SCENE_PG_keymesh,
 ]
 
@@ -82,6 +87,7 @@ def register():
     # PROPERTY
     bpy.types.Scene.keymesh = bpy.props.PointerProperty(type = SCENE_PG_keymesh, name="Keymesh")
     bpy.types.Object.keymesh = bpy.props.PointerProperty(type = OBJECT_PG_keymesh, name="Keymesh")
+    bpy.types.ID.keymesh = bpy.props.PointerProperty(type = DATA_PG_keymesh, name="Keymesh")
 
 def unregister():
     for cls in reversed(classes):
@@ -90,3 +96,4 @@ def unregister():
     # PROPERTY
     del bpy.types.Scene.keymesh
     del bpy.types.Object.keymesh
+    del bpy.types.ID.keymesh

--- a/ui.py
+++ b/ui.py
@@ -115,7 +115,7 @@ class VIEW3D_UL_keymesh_blocks(bpy.types.UIList):
         obj = context.object
         # item = item.block
 
-        obj_keymesh_data = obj.get("Keymesh Data")
+        obj_keymesh_data = obj.keymesh.get("Keymesh Data")
         block_keymesh_data = item.block.keymesh.get("Data")
         usage_count = keymesh_block_usage_count(self, context, item.block)
 

--- a/ui.py
+++ b/ui.py
@@ -53,7 +53,7 @@ class VIEW3D_PT_keymesh_frame_picker(bpy.types.Panel):
 
     @classmethod
     def poll(cls, context):
-        return context.object is not None and context.object.keymesh.get("Keymesh ID") is not None
+        return context.object is not None and context.object.keymesh.get("ID") is not None
 
     def draw(self, context):
         layout = self.layout

--- a/ui.py
+++ b/ui.py
@@ -116,7 +116,7 @@ class VIEW3D_UL_keymesh_blocks(bpy.types.UIList):
         # item = item.block
 
         obj_keymesh_data = obj.get("Keymesh Data")
-        block_keymesh_data = item.block.get("Keymesh Data")
+        block_keymesh_data = item.block.keymesh.get("Data")
         usage_count = keymesh_block_usage_count(self, context, item.block)
 
         col = layout.column(align=True)
@@ -126,7 +126,7 @@ class VIEW3D_UL_keymesh_blocks(bpy.types.UIList):
         if context.scene.keymesh.insert_on_selection and obj in context.editable_objects:
             select_icon = 'PINNED' if block_keymesh_data == obj_keymesh_data else 'UNPINNED'
         else:
-            if block_keymesh_data == obj.data.get("Keymesh Data") and block_keymesh_data != obj_keymesh_data:
+            if block_keymesh_data == obj.data.keymesh.get("Data") and block_keymesh_data != obj_keymesh_data:
                 select_icon = 'VIEWZOOM'
             elif block_keymesh_data == obj_keymesh_data:
                 select_icon = 'PINNED'

--- a/ui.py
+++ b/ui.py
@@ -53,7 +53,7 @@ class VIEW3D_PT_keymesh_frame_picker(bpy.types.Panel):
 
     @classmethod
     def poll(cls, context):
-        return context.object is not None and context.object.get("Keymesh ID") is not None
+        return context.object is not None and context.object.keymesh.get("Keymesh ID") is not None
 
     def draw(self, context):
         layout = self.layout

--- a/versioning.py
+++ b/versioning.py
@@ -10,7 +10,7 @@ def populate_keymesh_blocks(scene):
         # is_not_keymesh_object
         if obj.get("Keymesh Data") is None:
             continue
-        obj_keymesh_id = obj.get("Keymesh ID")
+        obj_keymesh_id = obj.keymesh.get("Keymesh ID")
 
         # list_objects_blocks
         unregistered_blocks = []

--- a/versioning.py
+++ b/versioning.py
@@ -10,7 +10,7 @@ def populate_keymesh_blocks(scene):
         # is_not_keymesh_object
         if obj.get("Keymesh Data") is None:
             continue
-        obj_keymesh_id = obj.keymesh.get("Keymesh ID")
+        obj_keymesh_id = obj.keymesh.get("ID")
 
         # list_objects_blocks
         unregistered_blocks = []

--- a/versioning.py
+++ b/versioning.py
@@ -8,7 +8,7 @@ from .functions.poll import obj_data_type
 def populate_keymesh_blocks(scene):
     for obj in bpy.data.objects:
         # is_not_keymesh_object
-        if obj.get("Keymesh Data") is None:
+        if obj.keymesh.get("Data") is None:
             continue
         obj_keymesh_id = obj.keymesh.get("ID")
 

--- a/versioning.py
+++ b/versioning.py
@@ -15,10 +15,10 @@ def populate_keymesh_blocks(scene):
         # list_objects_blocks
         unregistered_blocks = []
         for block in obj_data_type(obj):
-            if block.get("Keymesh ID") is None:
+            if block.keymesh.get("ID") is None:
                 continue
 
-            if block.get("Keymesh ID") == obj_keymesh_id:
+            if block.keymesh.get("ID") == obj_keymesh_id:
                 unregistered_blocks.append(block)
 
         # register_to_object

--- a/versioning.py
+++ b/versioning.py
@@ -7,24 +7,78 @@ from .functions.poll import obj_data_type
 @bpy.app.handlers.persistent
 def populate_keymesh_blocks(scene):
     for obj in bpy.data.objects:
-        # is_not_keymesh_object
-        if obj.keymesh.get("Data") is None:
+        # is_not_legacy_keymesh_object
+        if obj.get("Keymesh ID") is None:
             continue
-        obj_keymesh_id = obj.keymesh.get("ID")
+
+        # Convert Object Properties
+        obj_legacy_keymesh_id = obj.get("Keymesh ID", None)
+        obj_legacy_keymesh_data = obj.get("Keymesh Data", None)
+        obj.keymesh["ID"] = obj_legacy_keymesh_id
+        obj.keymesh["Keymesh Data"] = obj_legacy_keymesh_data
+        del obj["Keymesh ID"]
+        del obj["Keymesh Data"]
+        if obj.get("Keymesh Name") is not None:
+            del obj["Keymesh Name"]
 
         # list_objects_blocks
         unregistered_blocks = []
         for block in obj_data_type(obj):
-            if block.keymesh.get("ID") is None:
+            if block.get("Keymesh ID") is None:
                 continue
 
-            if block.keymesh.get("ID") == obj_keymesh_id:
+            if block.get("Keymesh ID") == obj_legacy_keymesh_id:
                 unregistered_blocks.append(block)
 
-        # register_to_object
+                # Convert Data Properties
+                block_legacy_keymesh_id = block.get("Keymesh ID", None)
+                block_legacy_keymesh_data = block.get("Keymesh Data", None)
+                block.keymesh["ID"] = block_legacy_keymesh_id
+                block.keymesh["Data"] = block_legacy_keymesh_data
+                del block["Keymesh ID"]
+                del block["Keymesh Data"]
+                if block.get("Keymesh Name") is not None:
+                    del block["Keymesh Name"]
+
+
+        # Register to Object
         for block in unregistered_blocks:
             block_registry = obj.keymesh.blocks.add()
             block_registry.block = block
+
+
+        # Transfer Animation
+        anim_data = obj.animation_data
+        if anim_data:
+            for fcurve in anim_data.action.fcurves:
+                if fcurve.data_path == '["Keymesh Data"]':
+                    original_fcurve = fcurve
+                    for keyframe in fcurve.keyframe_points:
+                        frame = int(keyframe.co[0])
+                        value = keyframe.co[1]
+                        
+                        obj.keymesh["Keymesh Data"] = value
+                        obj.keyframe_insert(data_path='keymesh["Keymesh Data"]', frame=frame)
+
+            # transfer_keyframe_values
+            for fcurve in anim_data.action.fcurves:
+                if fcurve.data_path == 'keymesh["Keymesh Data"]':
+                    for keyframe in fcurve.keyframe_points:
+                        frame = int(keyframe.co[0])
+                        for orig_keyframe in original_fcurve.keyframe_points:
+                            if int(orig_keyframe.co[0]) == frame:
+                                keyframe.interpolation = orig_keyframe.interpolation
+                                keyframe.easing = orig_keyframe.easing
+                                keyframe.handle_left_type = orig_keyframe.handle_left_type
+                                keyframe.handle_right_type = orig_keyframe.handle_right_type
+                                keyframe.handle_left = orig_keyframe.handle_left
+                                keyframe.handle_right = orig_keyframe.handle_right
+                                break
+
+            # remove_legacy_fcurve
+            for fcurve in anim_data.action.fcurves:
+                if fcurve.data_path == '["Keymesh Data"]':
+                    obj.animation_data.action.fcurves.remove(fcurve)
 
 
 


### PR DESCRIPTION
Similar to scene properties in #3 this PR moves Keymesh properties inside `PropertyGroup`, hidden from users.

Registering `PropertyGroup` on object is easy and it was done when registering `blocks` and `block_active_index`. But on object data types it's more tricky, since we need to dynamically get data type based on object and assign `PropertyGroup` to that type. For now I'm registering it on `bpy.types.ID` but it might be dangerous, since it adds it to all IDs inside Blender. There needs to be some sort of filtering (I'll look into that in the future).

- There might be some sort of "Debug" mode needed where `ID` and `Data` properties are exposed, because I might need them for manual debugging.

- For objects "Keymesh Data" keeps the name, which is inconsistent with blocks, but it's needed so that fcurve in animation editors is readable.