### PR TITLE
Library overrides support

### DIFF
--- a/functions/poll.py
+++ b/functions/poll.py
@@ -11,6 +11,18 @@ def is_candidate_object(context):
                                                           'LATTICE', 'LIGHT', 'LIGHT_PROBE', 'CAMERA', 'SPEAKER']
 
 
+def is_not_linked(context, obj=None):
+    if context.active_object is None:
+        return False
+    else:
+        if not obj:
+            obj = context.active_object
+        if obj in context.editable_objects:
+            if not obj.library and not obj.override_library:
+                return True
+
+
+
 def obj_data_type(obj):
     supported_types = [
         ('MESH', bpy.data.meshes),

--- a/operators/convert_shape_keys.py
+++ b/operators/convert_shape_keys.py
@@ -124,6 +124,7 @@ class OBJECT_OT_shape_keys_to_keymesh(bpy.types.Operator):
                     obj.keymesh["Keymesh Data"] = block_index
             else:
                 obj.keymesh["Keymesh Data"] = block_index
+            obj.keymesh.property_overridable_library_set('["Keymesh Data"]', True)
 
             # animate_keymesh_data
             if current_values != initial_values:

--- a/operators/convert_shape_keys.py
+++ b/operators/convert_shape_keys.py
@@ -1,6 +1,7 @@
 import bpy
 from .. import __package__ as base_package
 from ..functions.object import new_object_id, get_next_keymesh_index
+from ..functions.poll import is_not_linked
 
 
 #### ------------------------------ OPERATORS ------------------------------ ####
@@ -41,7 +42,7 @@ class OBJECT_OT_shape_keys_to_keymesh(bpy.types.Operator):
     @classmethod
     def poll(cls, context):
         return (context.active_object and context.active_object.type in ('MESH', 'CURVE', 'LATTICE')
-                and context.active_object.data.shape_keys is not None and context.active_object in context.editable_objects)
+                and context.active_object.data.shape_keys is not None and is_not_linked(context))
 
     # Naming Convention
     def naming_convention(self, key):

--- a/operators/frame_picker.py
+++ b/operators/frame_picker.py
@@ -29,7 +29,14 @@ class OBJECT_OT_keymesh_pick_frame(bpy.types.Operator):
         # Keyframe Block
         if obj in context.editable_objects:
             if scene.keymesh.insert_on_selection:
-                insert_keyframe(obj, keymesh_block, scene.frame_current)
+                action = obj.animation_data.action
+                if action:
+                    if action.library is None:
+                        insert_keyframe(obj, keymesh_block, scene.frame_current)
+                    else:
+                        self.report({'INFO'}, "You cannot animate in library overriden action. Create local one")
+                else:
+                    insert_keyframe(obj, keymesh_block, scene.frame_current)
 
             bpy.ops.object.mode_set(mode=current_mode)
         return {'FINISHED'}

--- a/operators/frame_picker.py
+++ b/operators/frame_picker.py
@@ -1,5 +1,5 @@
 import bpy
-from ..functions.poll import obj_data_type
+from ..functions.poll import is_not_linked, obj_data_type
 
 
 #### ------------------------------ OPERATORS ------------------------------ ####
@@ -49,7 +49,7 @@ class OBJECT_OT_keymesh_block_move(bpy.types.Operator):
 
     @classmethod
     def poll(cls, context):
-        return True
+        return is_not_linked(context)
 
     def execute(self, context):
         obj = context.active_object

--- a/operators/insert_keyframe.py
+++ b/operators/insert_keyframe.py
@@ -55,6 +55,7 @@ def insert_keymesh_keyframe(context, obj):
         obj.data = new_block
         obj.data.use_fake_user = True
         obj.keymesh["Keymesh Data"] = block_index
+        obj.keymesh.property_overridable_library_set('["Keymesh Data"]', True)
         block_registry = obj.keymesh.blocks.add()
         block_registry.block = new_block
         block_registry.name = new_block.name

--- a/operators/insert_keyframe.py
+++ b/operators/insert_keyframe.py
@@ -1,7 +1,7 @@
 import bpy
 from .. import __package__ as base_package
 from ..functions.object import new_object_id, get_next_keymesh_index
-from ..functions.poll import is_candidate_object
+from ..functions.poll import is_candidate_object, is_not_linked
 from ..functions.handler import update_keymesh
 
 
@@ -107,7 +107,7 @@ class OBJECT_OT_keymesh_insert(bpy.types.Operator):
         if prefs.enable_edit_mode:
             return is_candidate_object(context)
         else:
-            return (is_candidate_object(context) and context.active_object in context.editable_objects
+            return (is_candidate_object(context) and is_not_linked(context)
                     and context.mode not in ['EDIT_MESH', 'EDIT_CURVE', 'EDIT_SURFACE', 'EDIT_TEXT',
                                                  'EDIT_CURVES', 'EDIT_METABALL', 'EDIT_LATTICE'])
 

--- a/operators/purge_unused_data.py
+++ b/operators/purge_unused_data.py
@@ -1,7 +1,7 @@
 import bpy
 from ..functions.object import list_block_users
 from ..functions.handler import update_keymesh
-from ..functions.poll import obj_data_type
+from ..functions.poll import obj_data_type, is_not_linked
 from ..functions.timeline import get_keymesh_fcurve
 
 
@@ -21,7 +21,7 @@ class OBJECT_OT_purge_keymesh_data(bpy.types.Operator):
 
     @classmethod
     def poll(cls, context):
-        return context.active_object and context.active_object in context.editable_objects
+        return context.active_object and is_not_linked(context)
 
     def execute(self, context):
         # List Used Keymesh Blocks
@@ -139,7 +139,7 @@ class OBJECT_OT_keymesh_remove(bpy.types.Operator):
 
     @classmethod
     def poll(cls, context):
-        return context.active_object in context.editable_objects
+        return is_not_linked(context)
 
     def execute(self, context):
         obj = context.active_object

--- a/properties.py
+++ b/properties.py
@@ -31,6 +31,7 @@ class OBJECT_PG_keymesh(bpy.types.PropertyGroup):
     )
     block_active_index: bpy.props.IntProperty(
         name = "Active Block Index",
+        override = {"LIBRARY_OVERRIDABLE"},
         default = -1,
     )
 

--- a/ui.py
+++ b/ui.py
@@ -1,5 +1,5 @@
 import bpy
-from .functions.poll import prop_type, obj_data_type
+from .functions.poll import is_not_linked, prop_type, obj_data_type
 from .functions.timeline import keymesh_block_usage_count
 
 
@@ -26,14 +26,14 @@ class VIEW3D_PT_keymesh(bpy.types.Panel):
         row.prop(scene, "frame_skip_count", text="Frame Step")
         row.separator()
         row.prop(scene, "insert_keyframe_after_skip", text="")
-        if obj not in context.editable_objects:
+        if not is_not_linked(context, obj):
             row.enabled = False
 
         # Insert Keyframes
         column = layout.column()
         row = column.row(align=False)
         row.alignment = 'EXPAND'
-        if scene.insert_keyframe_after_skip and obj in context.editable_objects:
+        if scene.insert_keyframe_after_skip and is_not_linked(context, obj):
             row.operator("object.keyframe_object_data", text="Insert", icon_value=6).path="BACKWARD"
             row.operator("object.keyframe_object_data", text="", icon='DECORATE_KEYFRAME')
             row.operator("object.keyframe_object_data", text="Insert", icon_value=4).path="FORWARD"

--- a/ui.py
+++ b/ui.py
@@ -136,6 +136,7 @@ class VIEW3D_UL_keymesh_blocks(bpy.types.UIList):
     """List of Keymesh data-blocks for active object"""
     def draw_item(self, context, layout, data, item, icon, active_data, active_property, index):
         obj = context.active_object
+        action = obj.animation_data.action if obj.animation_data else None
         # item = item.block
 
         obj_keymesh_data = obj.keymesh.get("Keymesh Data")
@@ -146,7 +147,7 @@ class VIEW3D_UL_keymesh_blocks(bpy.types.UIList):
         row = col.row(align=True)
 
         # insert_button_icon
-        if context.scene.keymesh.insert_on_selection and obj in context.editable_objects:
+        if context.scene.keymesh.insert_on_selection and obj in context.editable_objects and (action and action.library is None):
             select_icon = 'PINNED' if block_keymesh_data == obj_keymesh_data else 'UNPINNED'
         else:
             if block_keymesh_data == obj.data.keymesh.get("Data") and block_keymesh_data != obj_keymesh_data:

--- a/versioning.py
+++ b/versioning.py
@@ -19,6 +19,7 @@ def populate_keymesh_blocks(scene):
         obj_legacy_keymesh_data = obj.get("Keymesh Data", None)
         obj.keymesh["ID"] = new_id
         obj.keymesh["Keymesh Data"] = obj_legacy_keymesh_data
+        obj.keymesh.property_overridable_library_set('["Keymesh Data"]', True)
         del obj["Keymesh ID"]
         del obj["Keymesh Data"]
         if obj.get("Keymesh Name") is not None:


### PR DESCRIPTION
This PR continues #4 to make Keymesh objects usable on linked objects.

The general plan is to disallow every operation on library overridden objects, except the main property which can be animated. This means no new blocks can be created (or deleted) but they can be inserted in the timeline, rearranged, etc. This will support workflows where animator creates all necessary blocks in library file, and animates them in scene files (replacement parts workflow, I will document this better somewhere in future).

It is somewhat limiting, but I think great starting point for library overrides. More involved workflows need clear design and feedback. I'm also not sure how far we can push this system.

---

To-do:

- [x] Create `is_not_linked_` poll function
- [x] Disable operators and UI for library overriden objects (except Pick Frame, which is needed for animation replacement parts)
- [x] Disable "Move Keymesh Block" operator for linked object (It needs to be seen if it works for library overridden)
- [x] Make `Keymesh Data` property library-overridable
- [ ] ~Check if `block_active_index` can be made library-overridable~