### PR TITLE
Animate visibility in "Convert to Separate Objects" operator

### DIFF
--- a/operators/separate_objects.py
+++ b/operators/separate_objects.py
@@ -20,6 +20,14 @@ class OBJECT_OT_keymesh_to_objects(bpy.types.Operator):
         default = "PRINT",
     )
 
+    naming_convention: bpy.props.EnumProperty(
+        name = "Naming Convention",
+        description = "Choose how newly created objects are named",
+        items = [("FRAMES", "Frames", "Objects will be named after frame on which they're created"),
+                ("BLOCKS", "Keymesh Blocks", "Objects will be named after the Keymesh block they represent")],
+        default = 'FRAMES',
+    )
+
     keep_position: bpy.props.BoolProperty(
         name = "Keep Position",
         description = "If enabled new objects will be in the same position as original. If disabled they'll be moved along the selected axis",
@@ -56,6 +64,9 @@ class OBJECT_OT_keymesh_to_objects(bpy.types.Operator):
         layout.prop(self, "workflow", expand=True)
         layout.separator()
 
+        layout.prop(self, "naming_convention")
+        layout.separator()
+
         # position
         if self.workflow == "PRINT":
             layout.prop(self, "keep_position")
@@ -90,7 +101,10 @@ class OBJECT_OT_keymesh_to_objects(bpy.types.Operator):
             if current_value != previous_value:
                 # Duplicate Object
                 dup_obj = obj.copy()
-                dup_obj.name = obj.name + "_frame_" + str(frame)
+                if self.naming_convention == "FRAMES":
+                    dup_obj.name = obj.name + "_frame_" + str(frame)
+                elif self.naming_convention == "BLOCKS":
+                    dup_obj.name = obj.data.name
                 dup_obj.animation_data_clear()
                 context.collection.objects.link(dup_obj)
 
@@ -119,6 +133,7 @@ class OBJECT_OT_keymesh_to_objects(bpy.types.Operator):
                                             frame=frame)
                     dup_obj.keyframe_insert(data_path='hide_render',
                                             frame=frame)
+
                     if prev_obj is not None:
                         # keyframe_previous_object
                         prev_obj.hide_viewport = True

--- a/operators/separate_objects.py
+++ b/operators/separate_objects.py
@@ -163,6 +163,7 @@ class OBJECT_OT_keymesh_to_objects(bpy.types.Operator):
                 previous_value = current_value
 
         obj.select_set(False)
+        obj.hide_set(True)
         context.scene.frame_set(initial_frame)
         return {'FINISHED'}
 


### PR DESCRIPTION
This feature allows each newly created object by "Convert to Separate Objects" operator to have viewport and render visibility animated so that the final result looks exactly the same as Keymesh animation. Since Keymesh animation is just multiple data-blocks swapped on a single object on given frames, we can easily use multiple objects (one object for one block) instead of one, and by animating their visibility to match the visibility of Keymesh blocks, we can get the same animation, but without Keymesh.

"Convert to Separate Objects" operator already allowed creating objects for each block, but was made for 3D printing purposes and supported lining up objects in the viewport. Now, just by keeping them in their original position and animation visibility we get the desired operator.

---

Since this operator now supports two kinds of workflows, some changes are needed for good UX:
- [x] Create property for animating visibility
- [x] Disallow changing objects position if `animate_visibility` is checked
- [x] Turn boolean property into enum "Workflow". Choice should is between "3D Printing" and "Rendering"
- [x] Property that chooses naming convention between keeping block names, or naming after frames
- [x] Hide and deselect original object after completion