### PR TITLE
Handle duplicates in "Convert to Separate Objects" operator

### DIFF
--- a/operators/separate_objects.py
+++ b/operators/separate_objects.py
@@ -155,7 +155,8 @@ class OBJECT_OT_keymesh_to_objects(bpy.types.Operator):
                             dup_obj.hide_viewport = False
                             dup_obj.hide_render = False
 
-                    duplicates.append(obj.data)
+                    if obj.data not in duplicates:
+                        duplicates.append(obj.data)
 
 
                 # Animate Visibility
@@ -173,7 +174,6 @@ class OBJECT_OT_keymesh_to_objects(bpy.types.Operator):
                         dup_obj.hide_render = True
                         self.animate_visibility(dup_obj, frame-1)
 
-
                 if self.workflow == "PRINT":
                     # Offset Duplicates
                     if not self.keep_position:
@@ -186,11 +186,14 @@ class OBJECT_OT_keymesh_to_objects(bpy.types.Operator):
 
 
         # Print about Duplicates
-        if self.handle_duplicates:
-            self.report({'INFO'}, "Duplicates were removed. Read console for more information")
-            if self.workflow == "PRINT":
-                for duplicate in duplicates:
-                    usage, frames = keymesh_block_usage_count(self, context, duplicate)
+        if self.handle_duplicates and len(duplicates) >= 1:
+            self.report({'INFO'}, "Duplicates were detected. Read console for more information")
+            for duplicate in duplicates:
+                usage, frames = keymesh_block_usage_count(self, context, duplicate)
+                if self.workflow == "RENDER":
+                    if self.handling_method == "INSTANCE":
+                        print("Object data '" + duplicate.name + "' is instanced " + str(usage) + " times on frames: " + str(frames))
+                if self.workflow == "PRINT":
                     print(duplicate.name + " was used " + str(usage) + " times on frames: " + str(frames))
 
         obj.select_set(False)

--- a/operators/separate_objects.py
+++ b/operators/separate_objects.py
@@ -130,13 +130,14 @@ class OBJECT_OT_keymesh_to_objects(bpy.types.Operator):
 
             if current_value != previous_value:
                 if not (self.handle_duplicates and current_value in unused_values):
-                    # Duplicate Object
+                    # Create New Object
                     dup_obj = self.create_object(context, obj, obj.data.copy(), frame, duplicates_collection)
                     unused_values.append(current_value)
                     uniques[dup_obj] = current_value
 
                 else:
                     if self.workflow == "RENDER" and self.handle_duplicates:
+                        # find_match_for_duplicate
                         match = None
                         for unique, value in uniques.items():
                             if value == current_value:
@@ -145,6 +146,12 @@ class OBJECT_OT_keymesh_to_objects(bpy.types.Operator):
                         # Create Instance Object
                         if self.handling_method == "INSTANCE":
                             dup_obj = self.create_object(context, match, match.data, frame, duplicates_collection, instance=True)
+                            dup_obj.hide_viewport = False
+                            dup_obj.hide_render = False
+
+                        # Reuse Same Object for Animation
+                        if self.handling_method == "REUSE":
+                            dup_obj = match
                             dup_obj.hide_viewport = False
                             dup_obj.hide_render = False
 

--- a/operators/separate_objects.py
+++ b/operators/separate_objects.py
@@ -126,7 +126,6 @@ class OBJECT_OT_keymesh_to_objects(bpy.types.Operator):
             context.scene.frame_set(frame)
             current_value = obj.keymesh["Keymesh Data"]
 
-            # if current_value != previous_value:
             if not (self.handle_duplicates and current_value in uniques.values()):
                 # Create New Object
                 dup_obj = self.create_object(context, obj, obj.data.copy(), frame, duplicates_collection)
@@ -145,12 +144,11 @@ class OBJECT_OT_keymesh_to_objects(bpy.types.Operator):
                     # Reuse Same Object for Animation
                     if self.handling_method == 'REUSE':
                         dup_obj = match
-
                     dup_obj.hide_viewport = False
                     dup_obj.hide_render = False
-                else:
-                    prev_obj = None
 
+                if self.workflow == 'PRINT':
+                    prev_obj = None
                 if obj.data not in duplicates:
                     duplicates.append(obj.data)
 
@@ -160,7 +158,6 @@ class OBJECT_OT_keymesh_to_objects(bpy.types.Operator):
                     continue
                 else:
                     self.animate_visibility(dup_obj, frame)
-
                     if prev_obj is not None:
                         # keyframe_previous_object
                         prev_obj.hide_viewport = True
@@ -177,9 +174,8 @@ class OBJECT_OT_keymesh_to_objects(bpy.types.Operator):
                 if not self.keep_position:
                     if prev_obj is not None:
                         dup_obj.location[move_axis_index] = prev_obj.location[move_axis_index] + self.offset_distance
-                    prev_obj = dup_obj
-            else:
-                prev_obj = dup_obj
+
+            prev_obj = dup_obj
             previous_value = current_value
 
 


### PR DESCRIPTION
For both 3D printing and rendering workflows it's good to track duplicates and handle them in some way. Duplicate is a block which was used more than once in Keymesh animation, and therefore (before this patch) is created multiple times as new object. Detecting and removing duplicates can avoid printing unnecessary replacement parts, or animating more objects than need to be.

Duplicates need to be handled differently for each workflow. Here is general to-do:
- [x] Add properties for handling duplicates
- [x] Don't create objects if "Handle Duplicates" is selected

To-do for rendering workflow:
- [x] Instancing method of duplicate handling: still creates new objects, but instances data from match, instead of copying
- [x] Reuse same object by animating it on every frame Keymesh block was appearing on
- [x] Print how many instances were created, or which objects were reused for animation

To-do for 3D printing workflow:
- [x] "Handle Duplicates" operator should be renamed to "Delete Duplicates" in UI, since that's what it does
- [x] Print statements about duplicates that were deleted 
- [ ] Properly line up new objects to create gaps for where duplicates should've been
- [ ] When "Keep Offset" is off, property to allow choosing between leaving gaps for duplicates, or not