### PR TITLE
Grid view UI and thumbnails for Keymesh blocks

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -11,7 +11,9 @@ bl_info = {
 }
 
 import bpy
+
 from .operators import register as operators_register, unregister as operators_unregister
+from .functions import register as functions_register, unregister as functions_unregister
 from . import (
     preferences,
     properties,
@@ -41,7 +43,9 @@ modules = [
 def register():
     for module in modules:
         module.register()
+
     operators_register()
+    functions_register()
 
     preferences.update_sidebar_category(bpy.context.preferences.addons[__package__].preferences, bpy.context)
     bpy.app.timers.register(update_properties_from_preferences)
@@ -54,7 +58,9 @@ def register():
 def unregister():
     for module in reversed(modules):
         module.unregister()
+
     operators_unregister()
+    functions_unregister()
 
     # HANDLERS
     bpy.app.handlers.load_post.remove(functions.handler.update_keymesh)

--- a/blender_manifest.toml
+++ b/blender_manifest.toml
@@ -19,5 +19,5 @@ license = [
   "SPDX:GPL-3.0-or-later",
 ]
 
-# platforms = ["windows-amd64", "macos-arm64", "linux-x86_64"]
-# Other supported platforms: "windows-arm64", "macos-x86_64"
+[permissions]
+files = "Store generated pose preview images and/or load them from disk"

--- a/functions/__init__.py
+++ b/functions/__init__.py
@@ -1,6 +1,24 @@
 import bpy
 
-from .handler import *
-from .object import *
-from .poll import *
-from .timeline import *
+from . import (
+    handler,
+    object,
+    poll,
+    thumbnail,
+    timeline,
+)
+
+
+#### ------------------------------ REGISTRATION ------------------------------ ####
+
+modules = [
+    thumbnail,
+]
+
+def register():
+    for module in modules:
+        module.register()
+
+def unregister():
+    for module in reversed(modules):
+        module.unregister()

--- a/functions/handler.py
+++ b/functions/handler.py
@@ -1,5 +1,6 @@
 import bpy, threading
 from .. import __package__ as base_package
+from .object import get_active_block_index
 
 
 #### ------------------------------ FUNCTIONS ------------------------------ ####
@@ -42,6 +43,22 @@ def update_keymesh(scene):
             obj.data.use_mirror_x = symmetry_x
             obj.data.use_mirror_y = symmetry_y
             obj.data.use_mirror_z = symmetry_z
+
+
+        # Update Active Index
+        scene = bpy.context.scene.keymesh
+        if scene.sync_with_timeline:
+            active_index = obj.keymesh.blocks_active_index
+
+            # find_index_of_active_keymesh_block
+            active_block_index = get_active_block_index(obj)
+
+            if active_index != active_block_index:
+                if bpy.context.scene.keymesh.grid_view:
+                    obj.keymesh.blocks_grid = str(active_block_index)
+                else:
+                    obj.keymesh.blocks_active_index = int(active_block_index)
+
 
 
 # @bpy.app.handlers.persistent

--- a/functions/handler.py
+++ b/functions/handler.py
@@ -53,7 +53,7 @@ def update_keymesh(scene):
             # find_index_of_active_keymesh_block
             active_block_index = get_active_block_index(obj)
 
-            if active_index != active_block_index:
+            if (active_index != active_block_index) and (active_block_index >= 0):
                 if bpy.context.scene.keymesh.grid_view:
                     obj.keymesh.blocks_grid = str(active_block_index)
                 else:

--- a/functions/object.py
+++ b/functions/object.py
@@ -68,3 +68,15 @@ def create_back_up(context, obj, data):
     for coll in backup.users_collection:
         if coll not in target_colls:
             coll.objects.unlink(backup)
+
+
+def get_active_block_index(obj):
+    """Returns index for active Keymesh block (current object data)"""
+    """NOTE: Necessary to get with iterations since no direct way to access index for CollectionProperty items"""
+
+    active_block_index = None
+    for i, block in enumerate(obj.keymesh.blocks):
+        if block.name == obj.data.name:
+            active_block_index = i
+    
+    return active_block_index

--- a/functions/thumbnail.py
+++ b/functions/thumbnail.py
@@ -1,0 +1,60 @@
+import bpy, os
+
+
+#### ------------------------------ FUNCTIONS ------------------------------ ####
+
+_item_map = dict()
+def _make_enum_item(id, name, descr, preview_id, uid):
+    """NOTE: This workaround is needed because names are not correctly populated in Enums due to known Blender bug."""
+    """It populates dictionary for each item with enum_item properties and then assigns them to new enum_item."""
+
+    lookup = f"{str(id)}\0{str(name)}\0{str(descr)}\0{str(preview_id)}\0{str(uid)}"
+    if not lookup in _item_map:
+        _item_map[lookup] = (id, name, descr, preview_id, uid)
+    return _item_map[lookup]
+
+
+preview_collections = {}
+def keymesh_blocks_enum_items(self, context):
+    """Generate EnumProperty from `keymesh.blocks` CollectionProperty"""
+    """Loads thumbnail image for each block from block.thumbnail StringProperty filepath"""
+
+    pcoll = preview_collections["main"]
+    enum_items = []
+
+    for i, block in enumerate(self.id_data.keymesh.blocks):
+        # Get Thumbnail
+        if block.thumbnail in pcoll:
+            thumbnail = pcoll[block.thumbnail].icon_id
+        else:
+            if block.thumbnail != "":
+                thumbnail = pcoll.load(block.thumbnail, bpy.path.abspath(block.thumbnail), 'IMAGE').icon_id
+            else:
+                thumbnail = 'DECORATE'
+
+        enum_items.append(_make_enum_item(str(i), block.name, "", thumbnail, i))
+
+    # sort_by_index
+    enum_items.sort(key=lambda item: item[4])
+
+    return enum_items
+
+
+
+#### ------------------------------ REGISTRATION ------------------------------ ####
+
+def previews_register():
+    pcoll = bpy.utils.previews.new()
+    preview_collections["main"] = pcoll
+
+def register():
+    previews_register()
+
+
+def previews_unregister():
+    for pcoll in preview_collections.values():
+        bpy.utils.previews.remove(pcoll)
+    preview_collections.clear()
+
+def unregister():
+    previews_unregister()

--- a/operators/frame_picker.py
+++ b/operators/frame_picker.py
@@ -85,10 +85,6 @@ class OBJECT_OT_keymesh_block_set_active(bpy.types.Operator):
         default = 'NEXT'
     )
 
-    @classmethod
-    def poll(cls, context):
-        return is_not_linked(context)
-
     def execute(self, context):
         obj = context.active_object
         index = int(obj.keymesh.blocks_active_index)

--- a/operators/frame_picker.py
+++ b/operators/frame_picker.py
@@ -60,15 +60,53 @@ class OBJECT_OT_keymesh_block_move(bpy.types.Operator):
 
     def execute(self, context):
         obj = context.active_object
-        index = int(obj.keymesh.block_active_index)
+        index = int(obj.keymesh.blocks_active_index)
 
         if self.direction == 'UP' and index > 0:
             obj.keymesh.blocks.move(index, index - 1)
-            obj.keymesh.block_active_index -= 1
+            obj.keymesh.blocks_active_index -= 1
 
         elif self.direction == 'DOWN' and (index + 1) < len(obj.keymesh.blocks):
             obj.keymesh.blocks.move(index, index + 1)
-            obj.keymesh.block_active_index += 1
+            obj.keymesh.blocks_active_index += 1
+        return {'FINISHED'}
+
+
+class OBJECT_OT_keymesh_block_set_active(bpy.types.Operator):
+    bl_idname = "object.keymesh_block_set_active"
+    bl_label = "Change Active Keymesh Block"
+    bl_description = "Change active keymesh block in grid view of frame picker"
+    bl_options = {'UNDO'}
+
+    direction: bpy.props.EnumProperty(
+        name = "Direction",
+        items = [('NEXT', "Next", "Change to next Keymesh block in the grid"),
+                ('PREVIOUS', "Previous", "Change to previous Keymesh block in the grid"),],
+        default = 'NEXT'
+    )
+
+    @classmethod
+    def poll(cls, context):
+        return is_not_linked(context)
+
+    def execute(self, context):
+        obj = context.active_object
+        index = int(obj.keymesh.blocks_active_index)
+
+        # set_`blocks_active_index`_if_it_is_not_set_(-1)
+        if index < 0:
+            obj.keymesh.blocks_active_index = int(obj.keymesh.blocks_grid)
+
+        if self.direction == 'PREVIOUS':
+            if index > 0:
+                obj.keymesh.blocks_active_index -= 1
+
+        if self.direction == 'NEXT':
+            if (index + 1) < len(obj.keymesh.blocks):
+                obj.keymesh.blocks_active_index += 1
+
+        obj.keymesh.blocks_grid = str(obj.keymesh.blocks_active_index)
+
         return {'FINISHED'}
 
 
@@ -78,6 +116,7 @@ class OBJECT_OT_keymesh_block_move(bpy.types.Operator):
 classes = [
     OBJECT_OT_keymesh_pick_frame,
     OBJECT_OT_keymesh_block_move,
+    OBJECT_OT_keymesh_block_set_active,
 ]
 
 def register():

--- a/operators/purge_unused_data.py
+++ b/operators/purge_unused_data.py
@@ -145,8 +145,8 @@ class OBJECT_OT_keymesh_remove(bpy.types.Operator):
         obj = context.active_object
         if obj and obj.keymesh.animated:
             # get_active_block
-            if obj.keymesh.block_active_index is not None:
-                block = obj.keymesh.blocks[obj.keymesh.block_active_index].block
+            if obj.keymesh.blocks_active_index is not None:
+                block = obj.keymesh.blocks[obj.keymesh.blocks_active_index].block
                 block_keymesh_data = block.keymesh.get("Data")
             else:
                 block = obj.data

--- a/properties.py
+++ b/properties.py
@@ -22,7 +22,8 @@ def keymesh_blocks_coll_update(self, context):
     """NOTE: To make this work all enum_item id names should be str(i)."""
 
     if context.scene.keymesh.grid_view == False:
-        self.blocks_grid = str(self.blocks_active_index)
+        if self.blocks_active_index >= 0:
+            self.blocks_grid = str(self.blocks_active_index)
 
 
 

--- a/properties.py
+++ b/properties.py
@@ -66,12 +66,13 @@ class OBJECT_PG_keymesh(bpy.types.PropertyGroup):
     blocks_grid: bpy.props.EnumProperty(
         name = "Keymesh Blocks",
         options = {'HIDDEN', 'LIBRARY_EDITABLE'},
+        override = {"LIBRARY_OVERRIDABLE"},
         items = keymesh_blocks_enum_items,
         update = keymesh_blocks_enum_update,
     )
     blocks_active_index: bpy.props.IntProperty(
         name = "Active Block Index",
-        options = {'HIDDEN'},
+        options = {'HIDDEN', 'LIBRARY_EDITABLE'},
         override = {"LIBRARY_OVERRIDABLE"},
         update = keymesh_blocks_coll_update,
         default = -1,

--- a/properties.py
+++ b/properties.py
@@ -31,15 +31,18 @@ def keymesh_blocks_coll_update(self, context):
 class KeymeshBlocks(bpy.types.PropertyGroup):
     block: bpy.props.PointerProperty(
         name = "Block",
+        options = {'HIDDEN'},
         type = bpy.types.ID,
     )
     name: bpy.props.StringProperty(
         name = "Name",
+        options = {'HIDDEN'},
         update = update_block_name,
     )
     thumbnail: bpy.props.StringProperty(
         name = "Thumbnail",
         subtype = 'FILE_PATH',
+        override = {"LIBRARY_OVERRIDABLE"},
         options = {'HIDDEN'},
     )
 
@@ -49,6 +52,7 @@ class OBJECT_PG_keymesh(bpy.types.PropertyGroup):
 
     animated: bpy.props.BoolProperty(
         name = "Has Keymesh Animation",
+        options = {'HIDDEN'},
         default = False,
     )
 
@@ -56,14 +60,17 @@ class OBJECT_PG_keymesh(bpy.types.PropertyGroup):
     blocks: bpy.props.CollectionProperty(
         name = "Keymesh Blocks",
         type = KeymeshBlocks,
+        options = {'HIDDEN'},
     )
     blocks_grid: bpy.props.EnumProperty(
         name = "Keymesh Blocks",
+        options = {'HIDDEN', 'LIBRARY_EDITABLE'},
         items = keymesh_blocks_enum_items,
         update = keymesh_blocks_enum_update,
     )
     blocks_active_index: bpy.props.IntProperty(
         name = "Active Block Index",
+        options = {'HIDDEN'},
         override = {"LIBRARY_OVERRIDABLE"},
         update = keymesh_blocks_coll_update,
         default = -1,
@@ -91,11 +98,13 @@ class SCENE_PG_keymesh(bpy.types.PropertyGroup):
         name = "Insert Keyframe",
         description = ("When enabled, skipping frames forward or backwards from UI will also keyframe the object data\n"
                     "WARNING: jumping on the frame with existing Keymesh keyframe will overwrite it, but not delete it"),
+        options = {'HIDDEN'},
         default = True,
     )
     insert_on_selection: bpy.props.BoolProperty(
         name = "Keyframe Keymesh Blocks After Selection",
         description = "Automatically insert keyframe on current frame for Keymesh block when selecting it.",
+        options = {'HIDDEN'},
         default = True,
     )
 
@@ -108,6 +117,7 @@ class SCENE_PG_keymesh(bpy.types.PropertyGroup):
     sync_with_timeline: bpy.props.BoolProperty(
         name = "Synchronize with Timeline",
         description = "Make active Keymesh block also active item in frame picker UI when scrubbing timeline",
+        options = {'HIDDEN'},
         default = True,
     )
 

--- a/ui.py
+++ b/ui.py
@@ -119,12 +119,13 @@ class VIEW3D_PT_keymesh_frame_picker(bpy.types.Panel):
             fcurve = get_keymesh_fcurve(obj)
             is_keyframed = False
             is_active = False
-            for keyframe in fcurve.keyframe_points:
-                if keyframe.co.x == context.scene.frame_current:
-                    is_keyframed = True
-                    if int(keyframe.co.y) == obj.keymesh.blocks[int(obj.keymesh.blocks_grid)].block.keymesh["Data"]:
-                        is_active = True
-                    break
+            if fcurve:
+                for keyframe in fcurve.keyframe_points:
+                    if keyframe.co.x == context.scene.frame_current:
+                        is_keyframed = True
+                        if int(keyframe.co.y) == obj.keymesh.blocks[int(obj.keymesh.blocks_grid)].block.keymesh["Data"]:
+                            is_active = True
+                        break
 
             if is_active:
                 icon = 'DECORATE_KEYFRAME'
@@ -133,8 +134,8 @@ class VIEW3D_PT_keymesh_frame_picker(bpy.types.Panel):
                     icon = 'ANIM'
                 else:
                     icon = 'DECORATE_ANIMATE'
-            # else:
-            #     icon = 'DECORATE_KEYFRAME'
+            if not obj in context.editable_objects:
+                icon = 'VIEWZOOM'
 
             row.operator("object.keymesh_block_set_active", text="Previous", icon='BACK').direction='PREVIOUS'
             row.operator("object.keymesh_pick_frame", text="", icon=icon).keymesh_index = active_block.name

--- a/ui.py
+++ b/ui.py
@@ -1,5 +1,4 @@
 import bpy
-from .functions.object import get_active_block_index
 from .functions.poll import is_not_linked, prop_type, obj_data_type
 from .functions.timeline import get_keymesh_fcurve, keymesh_block_usage_count
 
@@ -105,7 +104,6 @@ class VIEW3D_PT_keymesh_frame_picker(bpy.types.Panel):
         else:
             active_index = obj.keymesh.blocks_active_index
             active_block = obj.keymesh.blocks[active_index]
-            active_block_index = get_active_block_index(obj)
 
             layout.template_icon_view(obj.keymesh, "blocks_grid", show_labels=True, scale=6)
             layout.prop(active_block, "thumbnail", text="")
@@ -118,20 +116,25 @@ class VIEW3D_PT_keymesh_frame_picker(bpy.types.Panel):
             row.alignment = 'EXPAND'
 
             # get_keyframe_icon_based_on_animation_state
-            if active_index != active_block_index:
-                fcurve = get_keymesh_fcurve(obj)
-                is_keyframed = False
-                for keyframe in fcurve.keyframe_points:
-                    if keyframe.co.x == context.scene.frame_current:
-                        is_keyframed = True
-                        break
+            fcurve = get_keymesh_fcurve(obj)
+            is_keyframed = False
+            is_active = False
+            for keyframe in fcurve.keyframe_points:
+                if keyframe.co.x == context.scene.frame_current:
+                    is_keyframed = True
+                    if int(keyframe.co.y) == obj.keymesh.blocks[int(obj.keymesh.blocks_grid)].block.keymesh["Data"]:
+                        is_active = True
+                    break
 
+            if is_active:
+                icon = 'DECORATE_KEYFRAME'
+            else:
                 if is_keyframed:
                     icon = 'ANIM'
                 else:
                     icon = 'DECORATE_ANIMATE'
-            else:
-                icon = 'DECORATE_KEYFRAME'
+            # else:
+            #     icon = 'DECORATE_KEYFRAME'
 
             row.operator("object.keymesh_block_set_active", text="Previous", icon='BACK').direction='PREVIOUS'
             row.operator("object.keymesh_pick_frame", text="", icon=icon).keymesh_index = active_block.name

--- a/ui.py
+++ b/ui.py
@@ -135,7 +135,10 @@ class VIEW3D_PT_keymesh_frame_picker(bpy.types.Panel):
                 else:
                     icon = 'DECORATE_ANIMATE'
             if not obj in context.editable_objects:
-                icon = 'VIEWZOOM'
+                if obj.keymesh.blocks[active_index].block != obj.data:
+                    icon = 'VIEWZOOM'
+                else:
+                    icon = 'PINNED'
 
             row.operator("object.keymesh_block_set_active", text="Previous", icon='BACK').direction='PREVIOUS'
             row.operator("object.keymesh_pick_frame", text="", icon=icon).keymesh_index = active_block.name


### PR DESCRIPTION
Current frame picker UI, which presents Keymesh blocks as a list is now considered the "List View" of the frame picker UI and this PR introduces the second, "Grid View". The point of the grid view is to provide a better way of visualizing Keymesh blocks as images, and for that second part of the feature is implemented - thumbnails for Keymesh blocks.

User can switch to grid view by clicking the grid icon in Frame Picker header in UI and will be presented with a preview template, in which each Keymesh block is represented with their thumbnail (if they have one). Active Keymesh block is always the one highlighted in picker and underneath is the `filepath` property for choosing a thumbnail from the disk.

---

Whole list of changes introduced in this PR includes:
- Keymesh blocks gain `thumbnail` StringProperty (filepath) property. Whatever image is chosen there is what is visualized in new grid view preview template. Property is available only in grid view.
- Active Keymesh block is now active in the frame picker UI too when scrubbing the timeline. This feature, although enabled for both list view and grid view, is necessary so that preview template in grid view always shows thumbnail of active Keymesh block. Behavior is controlled with scene property `sync_with_timeline`, and can be found in grid view (After future UI changes in list view it can be exposed there as well).
- New `object.keymesh_block_set_active` operator for changing active Keymesh block. It is shown in grid view (since list view doesn't need it because you can simply set new active by clicking on it) as two buttons - "Previous" and "Next". Changing active item in UI (either with this operator or by picking in the preview template) doesn't put keyframe or assign new object data to object, it simply makes the block active so that it can be inspected and keyframed by the user (similar behavior in list view when "Keyframe on Selection" is disabled, which will be gone in future to make the concept of active blocks consistent and easier to understand).
- `object.keymesh_pick_frame` operator is shown in grid view UI and puts keyframe for a block that is selected in the preview template. The icon for that operator is dynamic (Filled keyframe icon if selected block is also active; Animation icon if object has Keymesh property on current frame and keyframing will overwrite it, Empty keyframe icon if frame is free).
- Thumbnails are library-overridable.
- Disallowed animating Keymesh properties (both new and old) that shouldn't be animated, or doesn't make sense to.
- Files permission is added in `blender_manifest` since add-on now needs access to directory to pick thumbnails, and in future will also store generated ones.

Implementation details:
- Since only EnumProperty can be represented with `template_icon_view` new `keymesh.blocks_grid` property is registered on object which gets dynamically populated with items from `keymesh.blocks`.
- To make the feature seamless and present what is basically two different registries as different modes of one it was necessary to always have active items in EnumProperty and CollectionProperty match, so `update` is added for both. That way switching between list view and grid view is not noticeable.
- `get_active_block_index` function is introduced since there is no direct way of getting index of specified item in CollectionProperty.