### PR TITLE
"Extract Keymesh Block" operator

### DIFF
--- a/functions/timeline.py
+++ b/functions/timeline.py
@@ -4,15 +4,15 @@ import bpy
 #### ------------------------------ FUNCTIONS ------------------------------ ####
 
 def get_keymesh_fcurve(obj):
-    """Returns the Keymesh f-curve for obj"""
+    """Returns f-curve for Keymesh data property of obj"""
 
     fcurve = None
-    if obj.keymesh.animated:
-        if obj.animation_data is not None:
-            if obj.animation_data.action is not None:
-                for f in obj.animation_data.action.fcurves:
-                    if f.data_path == 'keymesh["Keymesh Data"]':
-                        fcurve = f
+    if obj.animation_data is not None:
+        if obj.animation_data.action is not None:
+            for f in obj.animation_data.action.fcurves:
+                if f.data_path == 'keymesh["Keymesh Data"]':
+                    fcurve = f
+                    break
 
     return fcurve
 

--- a/operators/purge_unused_data.py
+++ b/operators/purge_unused_data.py
@@ -1,5 +1,5 @@
 import bpy
-from ..functions.object import list_block_users
+from ..functions.object import list_block_users, remove_block
 from ..functions.handler import update_keymesh
 from ..functions.poll import is_linked, is_keymesh_object, obj_data_type
 from ..functions.timeline import get_keymesh_fcurve
@@ -132,7 +132,7 @@ class OBJECT_OT_purge_keymesh_data(bpy.types.Operator):
             self.report({'INFO'}, str(len(delete_keymesh_blocks)) + " Keymesh block(s) removed" + specifier)
 
         return {'FINISHED'}
-    
+
     def invoke(self, context, event):
         self.all = event.shift
         return self.execute(context)
@@ -171,12 +171,8 @@ class OBJECT_OT_keymesh_remove(bpy.types.Operator):
                     return {'CANCELLED'}
                 block = obj.keymesh.blocks[initial_index].block
 
-                # Remove Keyframes
-                fcurve = get_keymesh_fcurve(obj)
-                if fcurve:
-                    for keyframe in reversed(fcurve.keyframe_points.values()):
-                        if keyframe.co_ui[1] == block.keymesh.get("Data"):
-                            fcurve.keyframe_points.remove(keyframe)
+                # remove_from_block_registry
+                remove_block(obj, block)
 
                 # refresh_timeline
                 """NOTE: Scrubbing in timeline makes sure that correct object data is asigned based on previous found keyframe."""
@@ -184,11 +180,6 @@ class OBJECT_OT_keymesh_remove(bpy.types.Operator):
                 current_frame = context.scene.frame_current
                 context.scene.frame_set(current_frame + 1)
                 context.scene.frame_set(current_frame)
-
-                # remove_from_block_registry
-                for index, mesh_ref in enumerate(obj.keymesh.blocks):
-                    if mesh_ref.block == block:
-                        obj.keymesh.blocks.remove(index)
 
                 # make_previous_block_active
                 previous_block_index = initial_index - 1

--- a/ui.py
+++ b/ui.py
@@ -84,8 +84,7 @@ class VIEW3D_PT_keymesh_frame_picker(bpy.types.Panel):
             col.operator("object.keyframe_object_data", text="", icon='ADD').path='STILL'
             col.operator("object.remove_keymesh_block", text="", icon='REMOVE')
             col.separator()
-            col.operator("object.keymesh_extract", text="", icon='FILE_PARENT')
-            col.operator("object.purge_keymesh_data", text="", icon='TRASH')
+            col.menu("VIEW3D_MT_keymesh_special_menu", icon='DOWNARROW_HLT', text="")
             col.separator()
             col.operator("object.keymesh_block_move", text="", icon='TRIA_UP').direction='UP'
             col.operator("object.keymesh_block_move", text="", icon='TRIA_DOWN').direction='DOWN'
@@ -199,6 +198,16 @@ class VIEW3D_PT_keymesh_tools(bpy.types.Panel):
                 # panel.operator("object.keymesh_interpolate", text="INTERPOLATE")
 
 
+class VIEW3D_MT_keymesh_special_menu(bpy.types.Menu):
+    bl_label = "Keymesh Specials"
+
+    def draw(self, context):
+        layout = self.layout
+        layout.operator("object.keymesh_extract", icon='FILE_PARENT')
+        layout.separator()
+        layout.operator("object.purge_keymesh_data", text="Purge Unused Blocks", icon='TRASH')
+
+
 
 #### ------------------------------ /ui_list/ ------------------------------ ####
 
@@ -264,6 +273,7 @@ classes = [
     VIEW3D_PT_keymesh,
     VIEW3D_PT_keymesh_frame_picker,
     VIEW3D_PT_keymesh_tools,
+    VIEW3D_MT_keymesh_special_menu,
     VIEW3D_UL_keymesh_blocks,
 ]
 

--- a/ui.py
+++ b/ui.py
@@ -83,6 +83,8 @@ class VIEW3D_PT_keymesh_frame_picker(bpy.types.Panel):
             col = row.column(align=True)
             col.operator("object.keyframe_object_data", text="", icon='ADD').path='STILL'
             col.operator("object.remove_keymesh_block", text="", icon='REMOVE')
+            col.separator()
+            col.operator("object.keymesh_extract", text="", icon='FILE_PARENT')
             col.operator("object.purge_keymesh_data", text="", icon='TRASH')
             col.separator()
             col.operator("object.keymesh_block_move", text="", icon='TRIA_UP').direction='UP'


### PR DESCRIPTION
Adds new operator that can extract (or pop in python terms) selected Keymesh block from object, and make it separate object. It's useful (especially for static, non-animated Keymesh objects) when artist wants to remove specific blocks but keep them in scene, or work on them separately and later join in back to original Keymesh object.

- Newly created object (containing extracted block as object data) retains original object properties (animation data, modifiers, constraints, etc.), but all Keymesh properties are removed, including Keymesh f-curve if the object had it.
- If the original Keymesh object was animated all keyframes for extracted block (if any) are removed.
- Extracting the last block from the object removes that object altogether.
- New dropdown menu is added in Frame Pickers vertical buttons (known as "specials" menu in Blender) where extract operator lives. Purge operator was also moved there.

---

Implementation details:
- Extracted code for removing block from registry (and keyframes associated to it) from `object.remove_keymesh_block` as new function to be reused here.