### PR TITLE
Static (non-animated) Keymesh objects support

### DIFF
--- a/functions/handler.py
+++ b/functions/handler.py
@@ -13,6 +13,8 @@ def update_keymesh(scene):
     for obj in bpy.context.scene.objects:
         if not is_keymesh_object(obj):
             continue
+        if not obj.keymesh.animated:
+            continue
 
         obj_keymesh_data = obj.keymesh["Keymesh Data"]
 

--- a/functions/object.py
+++ b/functions/object.py
@@ -42,19 +42,23 @@ def list_block_users(block):
 
     users = []
     for obj in bpy.data.objects:
-        if obj.keymesh.animated:
+        if is_keymesh_object(obj):
             if block.keymesh.get("ID") == obj.keymesh.get("ID"):
                 users.append(obj)
 
     return users
 
 
-def assign_keymesh_id(obj):
+def assign_keymesh_id(obj, animate=False):
     """Assigns properties to obj required to make it Keymesh object"""
 
-    if obj.keymesh.animated is False:
+    if obj.keymesh.active is False:
+        obj.keymesh.active = True
         obj.keymesh["ID"] = new_object_id()
-        obj.keymesh.animated = True
+
+    if animate:
+        if obj.keymesh.animated is False:
+            obj.keymesh.animated = True
 
 
 def create_back_up(obj, data):
@@ -124,6 +128,7 @@ def remove_keymesh_properties(obj):
     """Removes all Keymesh properties from obj, making it regular object"""
 
     if is_keymesh_object(obj):
+        obj.keymesh.active = False
         obj.keymesh.animated = False
         obj.keymesh.blocks.clear()
         if obj.keymesh.get("ID", None):

--- a/functions/poll.py
+++ b/functions/poll.py
@@ -48,7 +48,7 @@ def is_instanced(data):
 def is_keymesh_object(obj):
     """Checks whether or not obj has Keymesh animation or blocks"""
 
-    if obj.keymesh.animated == True:
+    if obj.keymesh.active == True:
         if obj.keymesh.get("ID", None):
             if len(obj.keymesh.blocks) > 0:
                 return True

--- a/operators/convert_shape_keys.py
+++ b/operators/convert_shape_keys.py
@@ -90,7 +90,7 @@ class OBJECT_OT_shape_keys_to_keymesh(bpy.types.Operator):
             create_back_up(obj, original_data)
 
         # Assign Keymesh ID
-        assign_keymesh_id(obj)
+        assign_keymesh_id(obj, animate=True)
 
         for frame in range(frame_start, frame_end + 1):
             context.scene.frame_set(frame)

--- a/operators/frame_picker.py
+++ b/operators/frame_picker.py
@@ -41,7 +41,7 @@ class OBJECT_OT_keymesh_pick_frame(bpy.types.Operator):
 
         # account_for_non_animated_Keymesh_objects (properly_assign_block_by_changing_object_keymesh_data_as_well)
         block_keymesh_data = context.active_object.data.keymesh.get("Data")
-        if scene.keymesh.insert_on_selection == False and not obj.animation_data:
+        if scene.keymesh.insert_on_selection == False and not obj.keymesh.animated:
             obj.keymesh["Keymesh Data"] = int(block_keymesh_data)
 
 
@@ -49,10 +49,11 @@ class OBJECT_OT_keymesh_pick_frame(bpy.types.Operator):
         if obj in context.editable_objects:
             if scene.keymesh.insert_on_selection:
                 # create_action_if_object_isn't_animated
-                if not obj.animation_data:
+                if not obj.keymesh.animated:
                     new_action = bpy.data.actions.new(obj.name + "Action")
                     obj.animation_data_create()
                     obj.animation_data.action = new_action
+                    obj.keymesh.animated = True
 
                 action = obj.animation_data.action
                 if action:

--- a/operators/insert_keyframe.py
+++ b/operators/insert_keyframe.py
@@ -18,7 +18,7 @@ def insert_keymesh_keyframe(context, obj):
 
     if obj:
         # Assign Keymesh ID
-        assign_keymesh_id(obj)
+        assign_keymesh_id(obj, animate=True)
 
         # get_block_index
         block_index = get_next_keymesh_index(obj)

--- a/operators/interpolate.py
+++ b/operators/interpolate.py
@@ -12,7 +12,7 @@ class ANIM_OT_keymesh_interpolate(bpy.types.Operator):
 
     @classmethod
     def poll(cls, context):
-        return context.active_object and is_keymesh_object(context.active_object)
+        return context.active_object and is_keymesh_object(context.active_object) and context.active_object.keymesh.animated
 
     def execute(self, context):
         obj = context.active_object

--- a/operators/join_extract.py
+++ b/operators/join_extract.py
@@ -46,6 +46,9 @@ class OBJECT_OT_keymesh_join(bpy.types.Operator):
 
     def execute(self, context):
         target = context.active_object
+        keymesh_object = False
+        if is_keymesh_object(target):
+            keymesh_object = True
 
         # filter_sources
         sources = []
@@ -66,10 +69,6 @@ class OBJECT_OT_keymesh_join(bpy.types.Operator):
 
         if len(sources) > 0:
             # Prepare Target
-            keymesh_object = False
-            if is_keymesh_object(target):
-                keymesh_object = True
-
             assign_keymesh_id(target)
             if keymesh_object == False:
                 # turn_active_data_into_first_Keymesh_block

--- a/operators/purge_unused_data.py
+++ b/operators/purge_unused_data.py
@@ -160,37 +160,37 @@ class OBJECT_OT_keymesh_remove(bpy.types.Operator):
 
     def execute(self, context):
         obj = context.active_object
-        if obj and obj.keymesh.animated:
-            if len(obj.keymesh.blocks) <= 1:
-                bpy.data.objects.remove(obj)
+
+        if len(obj.keymesh.blocks) <= 1:
+            bpy.data.objects.remove(obj)
+        else:
+            initial_index = obj.keymesh.blocks_active_index
+
+            # get_active_block
+            if (initial_index is None) or (initial_index > len(obj.keymesh.blocks) - 1):
+                return {'CANCELLED'}
+            block = obj.keymesh.blocks[initial_index].block
+
+            # remove_from_block_registry
+            remove_block(obj, block)
+
+            # refresh_timeline
+            """NOTE: Scrubbing in timeline makes sure that correct object data is asigned based on previous found keyframe."""
+            """NOTE: Without this whole object is deleted because Blender thinks it doesn't have object data anymore."""
+            current_frame = context.scene.frame_current
+            context.scene.frame_set(current_frame + 1)
+            context.scene.frame_set(current_frame)
+
+            # make_previous_block_active
+            previous_block_index = initial_index - 1
+            if previous_block_index > -1:
+                obj.keymesh.blocks_active_index = previous_block_index
             else:
-                initial_index = obj.keymesh.blocks_active_index
+                obj.keymesh.blocks_active_index = 0
 
-                # get_active_block
-                if (initial_index is None) or (initial_index > len(obj.keymesh.blocks) - 1):
-                    return {'CANCELLED'}
-                block = obj.keymesh.blocks[initial_index].block
-
-                # remove_from_block_registry
-                remove_block(obj, block)
-
-                # refresh_timeline
-                """NOTE: Scrubbing in timeline makes sure that correct object data is asigned based on previous found keyframe."""
-                """NOTE: Without this whole object is deleted because Blender thinks it doesn't have object data anymore."""
-                current_frame = context.scene.frame_current
-                context.scene.frame_set(current_frame + 1)
-                context.scene.frame_set(current_frame)
-
-                # make_previous_block_active
-                previous_block_index = initial_index - 1
-                if previous_block_index > -1:
-                    obj.keymesh.blocks_active_index = previous_block_index
-                else:
-                    obj.keymesh.blocks_active_index = 0
-
-                # Purge
-                data_type = obj_data_type(obj)
-                data_type.remove(block)
+            # Purge
+            data_type = obj_data_type(obj)
+            data_type.remove(block)
 
         return {'FINISHED'}
 

--- a/operators/separate_objects.py
+++ b/operators/separate_objects.py
@@ -128,6 +128,7 @@ class OBJECT_OT_keymesh_to_objects(bpy.types.Operator):
 
         # remove_keymesh_data
         if instance == False:
+            dup_obj.keymesh.active = False
             dup_obj.keymesh.animated = False
             del dup_obj.keymesh["Keymesh Data"]
             del dup_obj.keymesh["ID"]

--- a/operators/timeline_jump.py
+++ b/operators/timeline_jump.py
@@ -20,7 +20,17 @@ class TIMELINE_OT_keymesh_frame_jump(bpy.types.Operator):
 
     @classmethod
     def poll(cls, context):
-        return context.active_object and is_keymesh_object(context.active_object)
+        if context.active_object:
+            if is_keymesh_object(context.active_object):
+                if context.active_object.keymesh.animated:
+                    return True
+                else:
+                    cls.poll_message_set("Active object doesn't have Keymesh animation")
+                    return False
+            else:
+                return False
+        else:
+            return False
 
     def execute(self, context):
         keyframes = get_keymesh_keyframes(context.active_object)

--- a/properties.py
+++ b/properties.py
@@ -67,6 +67,11 @@ class KeymeshBlocks(bpy.types.PropertyGroup):
 class OBJECT_PG_keymesh(bpy.types.PropertyGroup):
     # OBJECT-level PROPERTIES
 
+    active: bpy.props.BoolProperty(
+        name = "Keymesh Object",
+        options = set(),
+        default = False,
+    )
     animated: bpy.props.BoolProperty(
         name = "Has Keymesh Animation",
         options = set(),

--- a/versioning.py
+++ b/versioning.py
@@ -13,6 +13,9 @@ def populate_keymesh_blocks(scene):
         for obj in bpy.data.objects:
             # is_not_legacy_keymesh_object
             if (not obj.get("km_id")) and (not obj.get("Keymesh ID")):
+                if obj.keymesh.animated:
+                    if not obj.keymesh.active:
+                        obj.keymesh.active = True
                 continue
 
             new_id = new_object_id()

--- a/versioning.py
+++ b/versioning.py
@@ -29,6 +29,7 @@ def populate_keymesh_blocks(scene):
                 obj_legacy_keymesh_data = obj.get("Keymesh Data", None)
 
             obj.keymesh["ID"] = new_id
+            obj.keymesh.active = True
             obj.keymesh.animated = True
             obj.keymesh["Keymesh Data"] = obj_legacy_keymesh_data
             obj.keymesh.property_overridable_library_set('["Keymesh Data"]', True)
@@ -56,8 +57,6 @@ def populate_keymesh_blocks(scene):
 
                 if (block.get("Keymesh ID", None) == obj_legacy_keymesh_id) or (block.get("km_id", None) == obj_legacy_keymesh_id):
                     unregistered_blocks.append(block)
-
-                    print(block.name)
 
                     # Convert Data Properties
                     block_legacy_keymesh_data = None
@@ -121,6 +120,8 @@ def populate_keymesh_blocks(scene):
                 for fcurve in anim_data.action.fcurves:
                     if (fcurve.data_path == '["Keymesh Data"]') or (fcurve.data_path == '["km_datablock"]'):
                         obj.animation_data.action.fcurves.remove(fcurve)
+
+            print("Successfully versioned " + obj.name)
 
 
 


### PR DESCRIPTION
Since 6a27fadba784c63b58ee4bf92968344001e318e3 (#22) first steps have been made to support static (non-animated) objects for Keymesh. Previous two PRs make it possible to add Keymesh blocks to object without animating them, and fix some corresponding issues. This PR makes sure entire system, including all operators and handlers support static Keymesh objects and have special handling for them wherever it is necessary.

Support for Static Keymesh objects opens up new possible workflows with Keymesh. At the very least it allows users to approach making blocks and animating them separately and decide how they want to work, but most importantly it makes possible to use Keymesh as "mesh versioning" tool.

At the very core, Keymesh is a tool that allows storing multiple object data on an object. Default workflow is animating those data, but Keymesh should allow users to simply store multiple meshes on object and switch between them without requiring animation (it's still beneficial to animate mesh versions and scrub the timeline to see progression, but not always). Additionally, multiple new and old add-on operators make mesh versioning workflow most convenient (joining, extracting, converting to separate objects and lining up, generating thumbnails, listing them in UI and etc).

This PR:
- Adds new `keymesh.active` property. Previously `keymesh.animated` was used everywhere where we needed to know if we were dealing with Keymesh object or not. This made it difficult to differentiate between animated and static Keymesh objects. `keymesh.active` property now is used for all objects, and `keymesh.animated` only for those that have Keymesh animation.

---

Implementation details & additional benefits:
- Frame handler now only checks for animated Keymesh objects. Same for other places as well, reducing number of look-ups in animation data and/or scene objects.
- Versioning makes sure that all objects that were flagged with `keymesh.animated` also get `keymesh.active` flag. Downside is that it requires users to not disable versioning in preferences.
- Keyframe Object Data, Pick Frame (when "Keyframe on Selection" is on), and convert operators set `keymesh.animated` property, join operator does not.