### PR TITLE
Bake to Keymesh

### DIFF
--- a/functions/object.py
+++ b/functions/object.py
@@ -144,6 +144,16 @@ def update_active_index(obj, index=None):
     obj.keymesh.blocks_grid = str(index)
 
 
+def convert_to_mesh(context, obj):
+    """Low-level alternative to `bpy.ops.object.convert` for converting to meshes"""
+
+    depsgraph = context.evaluated_depsgraph_get()
+    eval_obj = obj.evaluated_get(depsgraph)
+    mesh = bpy.data.meshes.new_from_object(eval_obj, preserve_all_data_layers=True, depsgraph=depsgraph)
+
+    return mesh
+
+
 def duplicate_object(context, obj, block, name=None, hide=False, collection=False):
     """Creates duplicate of obj and assigns object data / block"""
 

--- a/functions/object.py
+++ b/functions/object.py
@@ -152,7 +152,8 @@ def duplicate_object(context, obj, block, name=None, hide=False, collection=Fals
     dup_obj = obj.copy()
     dup_obj.data = block
     dup_obj.name = name
-    context.view_layer.active_layer_collection.collection.objects.link(dup_obj)
+    context.collection.objects.link(dup_obj)
+    # context.view_layer.active_layer_collection.collection.objects.link(dup_obj)
 
     if obj.animation_data is not None:
         if obj.animation_data.action is not None:

--- a/functions/object.py
+++ b/functions/object.py
@@ -50,7 +50,8 @@ def list_block_users(block):
 
 
 def assign_keymesh_id(obj, animate=False):
-    """Assigns properties to obj required to make it Keymesh object"""
+    """Assigns properties to obj that are required to make it Keymesh object"""
+    """If obj is already Keymesh object nothing happens"""
 
     if obj.keymesh.active is False:
         obj.keymesh.active = True

--- a/functions/object.py
+++ b/functions/object.py
@@ -153,7 +153,6 @@ def duplicate_object(context, obj, block, name=None, hide=False, collection=Fals
     dup_obj.data = block
     dup_obj.name = name
     context.collection.objects.link(dup_obj)
-    # context.view_layer.active_layer_collection.collection.objects.link(dup_obj)
 
     if obj.animation_data is not None:
         if obj.animation_data.action is not None:

--- a/functions/object.py
+++ b/functions/object.py
@@ -61,26 +61,6 @@ def assign_keymesh_id(obj, animate=False):
             obj.keymesh.animated = True
 
 
-def create_back_up(obj, data):
-    """Creates hidden copy of obj and appends to object collections"""
-
-    backup = obj.copy()
-    backup.data = data
-    backup.name = obj.name + "_backup"
-    backup.hide_render = True
-    backup.hide_viewport = True
-
-    # add_backup_to_obj_collections
-    target_colls = obj.users_collection
-    for collection in target_colls:
-        collection.objects.link(backup)
-
-    # remove_backup_from_other_collections
-    for coll in backup.users_collection:
-        if coll not in target_colls:
-            coll.objects.unlink(backup)
-
-
 def get_active_block_index(obj):
     """Returns index (integer) for active Keymesh block (current object data)"""
     """NOTE: Necessary to get with iterations since there is no direct way to access index for CollectionProperty items"""
@@ -163,7 +143,7 @@ def update_active_index(obj, index=None):
     obj.keymesh.blocks_grid = str(index)
 
 
-def duplicate_object(context, obj, block, name=None):
+def duplicate_object(context, obj, block, name=None, hide=False, collection=False):
     """Creates duplicate of obj and assigns object data / block"""
 
     if name == None:
@@ -178,5 +158,21 @@ def duplicate_object(context, obj, block, name=None):
         if obj.animation_data.action is not None:
             dup_action = obj.animation_data.action.copy()
             dup_obj.animation_data.action = dup_action
+
+    if hide:
+        dup_obj.hide_render = True
+        dup_obj.hide_viewport = True
+
+    if collection:
+        # add_duplicate_to_originals_collections
+        target_colls = obj.users_collection
+        for collection in target_colls:
+            if dup_obj.name not in collection.objects:
+                collection.objects.link(dup_obj)
+
+        # remove_duplicate_from_other_collections
+        for coll in dup_obj.users_collection:
+            if coll not in target_colls:
+                coll.objects.unlink(dup_obj)
 
     return dup_obj

--- a/operators/__init__.py
+++ b/operators/__init__.py
@@ -1,7 +1,7 @@
 import bpy
 
 from . import (
-    convert_shape_keys,
+    bake,
     frame_picker,
     generate_thumbnails,
     initialize_handler,
@@ -17,7 +17,7 @@ from . import (
 #### ------------------------------ REGISTRATION ------------------------------ ####
 
 modules = [
-    convert_shape_keys,
+    bake,
     frame_picker,
     generate_thumbnails,
     initialize_handler,

--- a/operators/bake.py
+++ b/operators/bake.py
@@ -6,8 +6,9 @@ from ..functions.handler import update_keymesh
 
 
 class ArmatureModifierData:
-    def __init__(self, mod):
-        # general_odifier_properties
+    def __init__(self, mod, i):
+        # general_modifier_properties
+        self.index = i
         self.name = mod.name
         self.show_in_editmode = mod.show_in_editmode
         self.show_on_cage = mod.show_on_cage
@@ -125,10 +126,10 @@ class ANIM_OT_bake_to_keymesh(bpy.types.Operator):
 
         # armature_poll
         self.armature = False
-        for mod in obj.modifiers:
+        for i, mod in enumerate(obj.modifiers):
             if mod.type == 'ARMATURE':
                 if mod.object:
-                    self.armature_modifiers[mod.name] = ArmatureModifierData(mod)
+                    self.armature_modifiers[mod.name] = ArmatureModifierData(mod, i)
                     self.has_armature = True
                     self.armature = True
 
@@ -280,6 +281,9 @@ class ANIM_OT_bake_to_keymesh(bpy.types.Operator):
         # Finish
         update_keymesh(context.scene)
         context.scene.frame_set(initial_frame)
+        if any(value.index != 0 for value in self.armature_modifiers.values()):
+            self.report({'WARNING'}, "Armature modifier was not first, result may not be as expected")
+
         return {'FINISHED'}
 
 

--- a/operators/bake.py
+++ b/operators/bake.py
@@ -173,6 +173,20 @@ class ANIM_OT_bake_to_keymesh(bpy.types.Operator):
 
 
     def execute(self, context):
+        # define_frame_range
+        initial_frame = context.scene.frame_current
+        if self.follow_scene_range == True:
+            frame_start = context.scene.frame_start
+            frame_end = context.scene.frame_end
+        else:
+            frame_start = self.frame_start
+            frame_end = self.frame_end
+        
+        if frame_start > frame_end:
+            self.report({'ERROR'}, "Operation cancelled. Start frame can't be higher than end frame")
+            return {'CANCELLED'}
+
+
         # back_up_original_object
         original_obj = context.active_object
         original_data = original_obj.data
@@ -189,16 +203,6 @@ class ANIM_OT_bake_to_keymesh(bpy.types.Operator):
 
         # Assign Keymesh ID
         assign_keymesh_id(obj, animate=True)
-
-
-        # define_frame_range
-        initial_frame = context.scene.frame_current
-        if self.follow_scene_range == True:
-            frame_start = context.scene.frame_start
-            frame_end = context.scene.frame_end
-        else:
-            frame_start = self.frame_start
-            frame_end = self.frame_end
 
 
         unique_shape_key_values = {}

--- a/operators/bake.py
+++ b/operators/bake.py
@@ -120,6 +120,9 @@ class ANIM_OT_bake_to_keymesh(bpy.types.Operator):
     def invoke(self, context, event):
         obj = context.active_object
 
+        self.frame_start = context.scene.frame_start
+        self.frame_end = context.scene.frame_end
+
         # armature_poll
         self.armature = False
         for mod in obj.modifiers:

--- a/operators/bake.py
+++ b/operators/bake.py
@@ -223,13 +223,10 @@ class ANIM_OT_bake_to_keymesh(bpy.types.Operator):
         # define_frame_range
         initial_frame = context.scene.frame_current
         if self.follow_scene_range == True:
-            frame_start = context.scene.frame_start
-            frame_end = context.scene.frame_end
-        else:
-            frame_start = self.frame_start
-            frame_end = self.frame_end
-        
-        if frame_start > frame_end:
+            self.frame_start = context.scene.frame_start
+            self.frame_end = context.scene.frame_end
+
+        if self.frame_start > self.frame_end:
             self.report({'ERROR'}, "Operation cancelled. Start frame can't be higher than end frame")
             return {'CANCELLED'}
 
@@ -258,7 +255,7 @@ class ANIM_OT_bake_to_keymesh(bpy.types.Operator):
         unique_shape_keys_dict = {}
         unique_verts_dict = {}
 
-        for frame in range(frame_start, frame_end + 1):
+        for frame in range(self.frame_start, self.frame_end + 1):
             context.scene.frame_set(frame)
 
             # Detect Duplicate
@@ -333,13 +330,13 @@ class ANIM_OT_bake_to_keymesh(bpy.types.Operator):
 
                         mod.show_viewport = False
                         mod.show_render = False
-                        obj.keyframe_insert(data_path=f'modifiers["{mod.name}"].show_viewport', frame=frame_start)
-                        obj.keyframe_insert(data_path=f'modifiers["{mod.name}"].show_render', frame=frame_start)
+                        obj.keyframe_insert(data_path=f'modifiers["{mod.name}"].show_viewport', frame=self.frame_start)
+                        obj.keyframe_insert(data_path=f'modifiers["{mod.name}"].show_render', frame=self.frame_start)
 
                         mod.show_viewport = True
                         mod.show_render = True
-                        obj.keyframe_insert(data_path=f'modifiers["{mod.name}"].show_viewport', frame=frame_end + 1)
-                        obj.keyframe_insert(data_path=f'modifiers["{mod.name}"].show_render', frame=frame_end + 1)
+                        obj.keyframe_insert(data_path=f'modifiers["{mod.name}"].show_viewport', frame=self.frame_end + 1)
+                        obj.keyframe_insert(data_path=f'modifiers["{mod.name}"].show_render', frame=self.frame_end + 1)
 
 
         # Append Original Mesh in Blocks
@@ -349,8 +346,8 @@ class ANIM_OT_bake_to_keymesh(bpy.types.Operator):
             insert_block(obj, initial_data, block_index)
             obj.keymesh.blocks.move(block_index, 0)
 
-            insert_keyframe(obj, frame_start - 1, block_index)
-            insert_keyframe(obj, frame_end + 1, block_index)
+            insert_keyframe(obj, self.frame_start - 1, block_index)
+            insert_keyframe(obj, self.frame_end + 1, block_index)
 
 
         # Remove Back-up Object

--- a/operators/bake.py
+++ b/operators/bake.py
@@ -5,6 +5,26 @@ from ..functions.timeline import insert_keyframe
 from ..functions.handler import update_keymesh
 
 
+class ArmatureModifierData:
+    def __init__(self, mod):
+        # general_odifier_properties
+        self.name = mod.name
+        self.show_in_editmode = mod.show_in_editmode
+        self.show_on_cage = mod.show_on_cage
+        self.show_viewport = mod.show_viewport
+        self.show_render = mod.show_render
+        self.use_pin_to_last = mod.use_pin_to_last
+
+        # armature_modifier_props
+        self.object = mod.object
+        self.vertex_group = mod.vertex_group
+        self.invert_vertex_group = mod.invert_vertex_group
+        self.use_deform_preserve_volume = mod.use_deform_preserve_volume
+        self.use_multi_modifier = mod.use_multi_modifier
+        self.use_vertex_groups = mod.use_vertex_groups
+        self.use_bone_envelopes = mod.use_bone_envelopes
+
+
 #### ------------------------------ OPERATORS ------------------------------ ####
 
 class ANIM_OT_bake_to_keymesh(bpy.types.Operator):
@@ -14,7 +34,7 @@ class ANIM_OT_bake_to_keymesh(bpy.types.Operator):
                       "Keymesh block will be created for each frame of the given range with animation applied")
     bl_options = {'REGISTER', 'UNDO'}
 
-    # General
+    # Frame Range
     follow_scene_range: bpy.props.BoolProperty(
         name = "Scene Frame Range",
         description = "Use scene frame range start and end",
@@ -29,6 +49,13 @@ class ANIM_OT_bake_to_keymesh(bpy.types.Operator):
         default = 250, min = 1,
     )
 
+    # General
+    keep_original: bpy.props.BoolProperty(
+        name = "Keep Original Object Data",
+        description = ("Keep current object data as Keymesh block without baking animation into it.\n"
+                       "This keeps overall animation working if only middle part of it is baked to Keymesh"),
+        default = True,
+    )
     instance_duplicates: bpy.props.BoolProperty(
         name = "Instance Duplicates",
         description = ("Operator will detect if some blocks are exactly the same (same shape key values, same keyframes, etc).\n"
@@ -36,15 +63,32 @@ class ANIM_OT_bake_to_keymesh(bpy.types.Operator):
         default = False,
     )
 
+    # Armature
+    armature: bpy.props.BoolProperty(
+        name = "Bake Armature Animation",
+        description = ("Bake armature (rig) animation to Keymesh blocks.\n"
+                       "Armature modifier will be applied to every Keymesh block on the frame it's created.\n"
+                       "Meaning that armature deformations will be baked in for each block"),
+        default = True,
+    )
+    handle_armatures: bpy.props.EnumProperty(
+        name = "Handle Modifiers",
+        description = "What to do with armature modifiers after they're baked into Keymesh blocks",
+        items = (('DELETE', "Delete", ("Armature modifiers will be completely removed from the object.\n")),
+                 ('ANIMATE', "Animate Visibility", ("Viewport and render visibility for armature modifiers will be animated.\n"
+                                                    "Modifiers will be disabled when first Keymesh object becomes active, and re-enabled after last one.\n"
+                                                    "This way object can retain existing regular animation before and after Keymesh animation"))),
+        default = 'DELETE',
+    )
+
     # Shape Keys
     shape_keys: bpy.props.BoolProperty(
         name = "Bake Shape Keys",
         description = ("Bake shape key animation to Keymesh blocks.\n"
-                       "Animated shape keys will be applied on Keymesh blocks on the frame they're created"),
+                       "Animated shape keys will be applied on every Keymesh block on the frame it's created"),
         default = True,
     )
 
-    has_shape_keys = False
 
     @classmethod
     def poll(cls, context):
@@ -64,6 +108,59 @@ class ANIM_OT_bake_to_keymesh(bpy.types.Operator):
                 return False
         else:
             return False
+
+
+    def __init__(self):
+        self.has_shape_keys = False
+        self.has_armature = False
+
+        self.armature_modifiers = {}
+
+
+    def invoke(self, context, event):
+        obj = context.active_object
+
+        # armature_poll
+        self.armature = False
+        for mod in obj.modifiers:
+            if mod.type == 'ARMATURE':
+                if mod.object:
+                    self.armature_modifiers[mod.name] = ArmatureModifierData(mod)
+                    self.has_armature = True
+                    self.armature = True
+
+        # shape_key_poll
+        self.shape_keys = False
+        if obj.type in ('MESH', 'CURVE', 'LATTICE'):
+            if obj.data.shape_keys:
+                if obj.data.shape_keys.animation_data:
+                    self.has_shape_keys = True
+                    self.shape_keys = True
+
+        return context.window_manager.invoke_props_dialog(self)
+
+
+    def restore_armature_modifier(self, obj, stored_mod):
+        """Adds new armature modifier on object and assigns it value from stored (applied) one"""
+
+        restored_mod = obj.modifiers.new(name=stored_mod.name, type='ARMATURE')
+
+        restored_mod.name = stored_mod.name
+        restored_mod.show_in_editmode = stored_mod.show_in_editmode
+        restored_mod.show_on_cage = stored_mod.show_on_cage
+        restored_mod.show_viewport = stored_mod.show_viewport
+        restored_mod.show_render = stored_mod.show_render
+        restored_mod.use_pin_to_last = stored_mod.use_pin_to_last
+
+        restored_mod.object = stored_mod.object
+        restored_mod.vertex_group = stored_mod.vertex_group
+        restored_mod.invert_vertex_group = stored_mod.invert_vertex_group
+        restored_mod.use_deform_preserve_volume = stored_mod.use_deform_preserve_volume
+        restored_mod.use_multi_modifier = stored_mod.use_multi_modifier
+        restored_mod.use_vertex_groups = stored_mod.use_vertex_groups
+        restored_mod.use_bone_envelopes = stored_mod.use_bone_envelopes
+
+        return restored_mod
 
 
     def execute(self, context):
@@ -112,11 +209,7 @@ class ANIM_OT_bake_to_keymesh(bpy.types.Operator):
                 new_block = initial_data.copy()
                 new_block.name = obj.name + "_frame_" + str(frame)
 
-                # assign_new_block_to_object
-                block_index = get_next_keymesh_index(obj)
-                insert_block(obj, new_block, block_index)
-
-                if self.shape_keys:
+                if self.armature or self.shape_keys:
                     # Apply Shape Keys
                     obj.data = new_block
                     bpy.ops.object.shape_key_remove(all=True, apply_mix=True)
@@ -125,27 +218,67 @@ class ANIM_OT_bake_to_keymesh(bpy.types.Operator):
                     if self.instance_duplicates:
                         unique_shape_key_values[shape_key_values] = new_block
 
+                if self.armature:
+                    # Apply Armature Modifier
+                    obj.data = new_block
+                    for mod_name, mod_data in self.armature_modifiers.items():
+                        bpy.ops.object.modifier_apply(modifier=mod_name, report=False)
+
+                        # restore_armature_modifier
+                        obj.data = initial_data
+                        restored_mod = self.restore_armature_modifier(obj, mod_data)
+
+
+                # assign_new_block_to_object
+                block_index = get_next_keymesh_index(obj)
+                insert_block(obj, new_block, block_index)
+
 
             # Insert Keyframe
             obj.keymesh["Keymesh Data"] = block_index
             obj.keymesh.property_overridable_library_set('["Keymesh Data"]', True)
             insert_keyframe(obj, context.scene.frame_current)
 
+
+        # Handle Armatures
+        if self.armature:
+            for mod in obj.modifiers:
+                if mod.type == 'ARMATURE':
+                    # remove_armature_modifiers
+                    if self.handle_armatures == 'DELETE':
+                        obj.modifiers.remove(mod)
+                    # animate_modifier_visibility
+                    elif self.handle_armatures == 'ANIMATE':
+                        obj.keyframe_insert(data_path=f'modifiers["{mod.name}"].show_viewport', frame=context.scene.frame_start)
+                        obj.keyframe_insert(data_path=f'modifiers["{mod.name}"].show_render', frame=context.scene.frame_start)
+
+                        mod.show_viewport = False
+                        mod.show_render = False
+                        obj.keyframe_insert(data_path=f'modifiers["{mod.name}"].show_viewport', frame=frame_start)
+                        obj.keyframe_insert(data_path=f'modifiers["{mod.name}"].show_render', frame=frame_start)
+
+                        mod.show_viewport = True
+                        mod.show_render = True
+                        obj.keyframe_insert(data_path=f'modifiers["{mod.name}"].show_viewport', frame=frame_end + 1)
+                        obj.keyframe_insert(data_path=f'modifiers["{mod.name}"].show_render', frame=frame_end + 1)
+
+
+        # Append Original Mesh in Blocks
+        """NOTE: This has to be done at the end because being in `keymesh.blocks` makes mesh users 2 and modifiers don't apply"""
+        if self.keep_original:
+            block_index = get_next_keymesh_index(obj)
+            insert_block(obj, initial_data, block_index)
+            obj.keymesh.blocks.move(block_index, 0)
+
+            insert_keyframe(obj, frame_start - 1, block_index)
+            insert_keyframe(obj, frame_end + 1, block_index)
+
+
+        # Finish
         update_keymesh(context.scene)
         context.scene.frame_set(initial_frame)
         return {'FINISHED'}
 
-    def invoke(self, context, event):
-        obj = context.active_object
-
-        self.shape_keys = False
-        if obj.type in ('MESH', 'CURVE', 'LATTICE'):
-            if obj.data.shape_keys:
-                if obj.data.shape_keys.animation_data:
-                    self.has_shape_keys = True
-                    self.shape_keys = True
-
-        return context.window_manager.invoke_props_dialog(self)
 
     def draw(self, context):
         layout = self.layout
@@ -162,9 +295,23 @@ class ANIM_OT_bake_to_keymesh(bpy.types.Operator):
             col.enabled = False
 
         layout.separator()
+        layout.prop(self, "keep_original")
         layout.prop(self, "instance_duplicates")
 
-        header, panel = layout.panel("BAKE_OT_shape_keys", default_closed=False)
+        # Armature
+        header, panel = layout.panel("ANIM_OT_bake_to_keymesh_armature", default_closed=False)
+        header.label(text="Armature")
+        if panel:
+            if self.has_armature:
+                panel.prop(self, "armature")
+                panel.prop(self, "handle_armatures")
+            else:
+                row = panel.row()
+                row.alignment = 'RIGHT'
+                row.label(text="Active object doesn't use armature modifier", icon='INFO')
+
+        # Shape Keys
+        header, panel = layout.panel("ANIM_OT_bake_to_keymesh_shape_keys", default_closed=False)
         header.label(text="Shape Keys")
         if panel:
             if self.has_shape_keys:

--- a/operators/bake.py
+++ b/operators/bake.py
@@ -137,7 +137,8 @@ class ANIM_OT_bake_to_keymesh(bpy.types.Operator):
         # shape_key_poll
         if obj.type in ('MESH', 'CURVE', 'LATTICE'):
             if obj.data.shape_keys:
-                if obj.data.shape_keys.animation_data:
+                # if obj.data.shape_keys.animation_data:
+                if len(obj.data.shape_keys.key_blocks) > 1:
                     self.has_shape_keys = True
 
         return context.window_manager.invoke_props_dialog(self)
@@ -162,7 +163,7 @@ class ANIM_OT_bake_to_keymesh(bpy.types.Operator):
                 match = unique_shape_keys_dict[sk_values]
 
         # compare_vertex_positions
-        elif self.bake_type == 'ARMATURE' and self.has_armature:
+        elif self.bake_type == 'ARMATURE':
             depsgraph = context.evaluated_depsgraph_get()
             eval_obj = obj.evaluated_get(depsgraph)
 
@@ -378,7 +379,7 @@ class ANIM_OT_bake_to_keymesh(bpy.types.Operator):
                 if self.has_shape_keys == False:
                     row = panel.row()
                     row.alignment = 'RIGHT'
-                    row.label(text="Active object doesn't have shape key animation", icon='INFO')
+                    row.label(text="Active object doesn't have shape keys", icon='INFO')
 
             if obj.type == 'MESH' and self.bake_type != 'NOTHING':
                 panel.prop(self, "instance_duplicates")

--- a/operators/bake.py
+++ b/operators/bake.py
@@ -35,7 +35,7 @@ class ANIM_OT_bake_to_keymesh(bpy.types.Operator):
     bl_label = "Bake to Keymesh"
     bl_description = ("Bakes down objects animation (action, armature, shape key) into Keymesh blocks.\n"
                       "Keymesh block will be created for each frame of the given range with animation applied")
-    bl_options = {'REGISTER', 'UNDO'}
+    bl_options = {'UNDO'}
 
     # Frame Range
     follow_scene_range: bpy.props.BoolProperty(

--- a/ui.py
+++ b/ui.py
@@ -177,7 +177,7 @@ class VIEW3D_PT_keymesh_tools(bpy.types.Panel):
         layout.use_property_decorate = False
 
         layout.operator("object.keymesh_join")
-        layout.operator("object.shape_keys_to_keymesh")
+        layout.operator("anim.bake_to_keymesh")
         layout.operator("object.keymesh_to_objects", text="Convert to Separate Objects")
         layout.operator("scene.initialize_keymesh_handler", text="Initialize Frame Handler")
 


### PR DESCRIPTION
This PR greatly refactors/rewrites "Shape Keys to Keymesh" operator to make it general tool for baking regular animation into Keymesh blocks: object animation, armature animation, and possibly others. Having animation baked on Keymesh blocks gives user the ability to do frame-by-frame sculpting on finalized animation (or just parts of it). This is also the first step in better support of armatures in Keymesh.

## **Baking options:**
- <ins>Shape Keys:</ins> when enabled (and supported by object type) operator applies shape keys to each Keymesh block on the frame they're created, meaning it bakes down shape key deformations on block (mesh) level.

- <ins>Modifiers & Shape Keys:</ins> when chosen operator pop-up presets list of objects modifiers and user can select which modifiers to bake. Armature modifiers (as well as first modifier) are selected by default, but any modifier (and any number of modifiers) can be baked. Like shape keys, operator applies modifiers to each Keymesh block on the frame they're created, thus baking down modifier generations & deformations on block (mesh) level.
- - User has two options for handling modifiers after the operator is done:
- - 1. Remove: Modifiers are simply removed from the object.
- - 2. Animate Visibility: This is especially useful when only baking the middle part of the regular animation. It will keep modifiers and will animate their viewport & render visibility so that they're visible (i.e. influence object deformations) before Keymesh animation starts, and after, but not during. This allows users to have `Armature -> Keymesh -> Armature` transitions in their animation.

---

## **Other operator settings:**
- Option to <ins>keep the original data-block</ins> (i.e. turn it into a Keymesh block as well). It is most useful when only baking the middle of the regular animation because it will allow users to keep the mesh that hasn't had modifiers and/or shape keys applied. The original data-block is keyframed before the first baked Keymesh block and after the last, so that it creates `Armature -> Keymesh -> Armature` transitions in animation.
- Option to <ins>instance duplicates</ins>: The operator will run calculations to detect if the object is exactly the same on some frames (it has same shape key values, same armature deformation, etc). If the operator finds that mesh is the same on X and Y frames it will keyframe one Keymesh block on both frames, instead of creating two duplicates  (basically instancing one Keymesh block). This is an advanced option for more specialized uses, but is useful when the user wants to avoid having unnecessary blocks that are difficult to manage and sculpt onto later on.
- Option to <ins>back-up object</ins>: Duplicates object to keep keep a back-up (technically, object is duplicated regardless because it's important for the operator. What this property controls is whether or not duplicated object is removed by operator at the end).

---

**Implementation details**:
- Code for detecting shape key duplicates (blocks with same shape key values) has been rewritten. The original code was copied from the "Bake Shape Keys" add-on and was extremely faulty and unoptimized. Refactored it with the new detection mechanism, and greatly simplified the code.
- New generalized method of detecting duplicates uses `numpy.array` of evaluated objects vertex positions, and similarly to shape key values it checks if same array is already present in `unique_verts_dict` array. If there is it gets key (Keymesh block) of that array item, if not, appends array to the dict as unique. This makes sure all deformations are calculated and avoids having to implement separate methods for armatures and other modifiers.
- Storing modifier property values seems to be bugged, it only works from other object, so unfortunately duplicate has to be created regardless of back-up property. This complicates code a little bit. Hopefully can be figured out in the future.