### PR TITLE
Deploy link/append handlers

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -53,6 +53,7 @@ def register():
     # HANDLERS
     bpy.app.handlers.load_post.append(functions.handler.update_keymesh)
     bpy.app.handlers.frame_change_post.append(functions.handler.update_keymesh)
+    bpy.app.handlers.blend_import_post.append(functions.handler.append_keymesh)
 
 
 def unregister():
@@ -65,6 +66,7 @@ def unregister():
     # HANDLERS
     bpy.app.handlers.load_post.remove(functions.handler.update_keymesh)
     bpy.app.handlers.frame_change_post.remove(functions.handler.update_keymesh)
+    bpy.app.handlers.blend_import_post.remove(functions.handler.append_keymesh)
 
 
 if __name__ == "__main__":

--- a/functions/handler.py
+++ b/functions/handler.py
@@ -107,6 +107,10 @@ def append_keymesh(lapp_context):
                     if new_id != None:
                         data.keymesh["ID"] = new_id
 
+                    # Fix Name Collisions
+                    if block.name != data.name:
+                        block.name = data.name
+
                     # Make Thumbnails Relative
                     """NOTE: Since thumbnails (StringProperty) are set to relative in library files, they're incorrect when imported"""
                     """NOTE: this code gets absolute path for them and generates new path relative to receiving file"""

--- a/functions/handler.py
+++ b/functions/handler.py
@@ -1,6 +1,6 @@
 import bpy, os
 from .. import __package__ as base_package
-from .poll import is_keymesh_object
+from .poll import is_keymesh_object, supported_types
 from .timeline import get_keymesh_fcurve
 from .object import new_object_id, is_unique_id
 
@@ -84,7 +84,7 @@ def append_keymesh(lapp_context):
 
     for item in items:
         type = item.id_type
-        direct = False if 'INDIRECT_USAGE' not in item.import_info else True
+        direct = False if 'INDIRECT_USAGE' in item.import_info else True
         library = item.source_library
 
         # Detect Keymesh Object
@@ -100,7 +100,6 @@ def append_keymesh(lapp_context):
                     new_id = new_object_id()
                     obj.keymesh["ID"] = new_id
 
-                # detect_keymesh_blocks
                 for block in obj.keymesh.blocks:
                     data = block.block
 
@@ -121,6 +120,17 @@ def append_keymesh(lapp_context):
                             block.thumbnail = abs_thumbnail_path
                         else:
                             block.thumbnail = bpy.path.relpath(abs_thumbnail_path)
+
+
+        # Detect Keymesh Blocks
+        elif type in [t[0] for t in supported_types()]:
+            if direct:
+                # remove_keymesh_properties_from_directly_appended_blocks
+                block = item.id
+                if block.keymesh.get("ID", None):
+                    del block.keymesh["ID"]
+                if block.keymesh.get("Data", None):
+                    del block.keymesh["Data"]
 
 
     # update_frame_handler

--- a/functions/handler.py
+++ b/functions/handler.py
@@ -2,9 +2,10 @@ import bpy
 from .. import __package__ as base_package
 from .poll import is_keymesh_object
 from .timeline import get_keymesh_fcurve
+from .object import new_object_id, is_unique_id
 
 
-#### ------------------------------ FUNCTIONS ------------------------------ ####
+#### ------------------------------ /frame_handler/ ------------------------------ ####
 
 @bpy.app.handlers.persistent
 def update_keymesh(scene):
@@ -36,7 +37,7 @@ def update_keymesh(scene):
         # Find Correct Keymesh Block for Object (with Same Data)
         correct_block = None
         for block in obj.keymesh.blocks:
-            print("STILL CHECKING")
+            # print("STILL CHECKING")
             block_keymesh_data = block.block.keymesh["Data"]
             if block_keymesh_data != obj_keymesh_data:
                 continue
@@ -69,3 +70,37 @@ def update_keymesh(scene):
                             obj.keymesh.blocks_grid = str(active_block_index)
                         else:
                             obj.keymesh.blocks_active_index = int(active_block_index)
+
+
+
+#### ------------------------------ /append_handler/ ------------------------------ ####
+
+@bpy.app.handlers.persistent
+def append_keymesh(lapp_context):
+    options = lapp_context.options
+    items = lapp_context.import_items
+    stage = lapp_context.process_stage # return: 'INIT' (for pre) and 'DONE' (for post)
+
+    is_linking = True if 'LINK' in options else False
+
+    for item in items:
+        type = item.id_type
+        direct = False if 'INDIRECT_USAGE' not in item.import_info else True
+        library = item.source_library
+
+        # Keymesh Object
+        if type == 'OBJECT':
+            obj = item.id
+            if obj.keymesh.active:
+                km_id = obj.keymesh.get("ID", None)
+                new_id = None
+
+                # make_sure_id_is_unique
+                if not is_unique_id(obj, km_id):
+                    new_id = new_object_id()
+                    obj.keymesh["ID"] = new_id
+                    print("ID CHANGED to: ", str(new_id))
+
+                for block in obj.keymesh.blocks:
+                    if new_id != None:
+                        block.block.keymesh["ID"] = new_id

--- a/functions/handler.py
+++ b/functions/handler.py
@@ -37,7 +37,6 @@ def update_keymesh(scene):
         # Find Correct Keymesh Block for Object (with Same Data)
         correct_block = None
         for block in obj.keymesh.blocks:
-            # print("STILL CHECKING")
             block_keymesh_data = block.block.keymesh["Data"]
             if block_keymesh_data != obj_keymesh_data:
                 continue
@@ -95,11 +94,10 @@ def append_keymesh(lapp_context):
                 km_id = obj.keymesh.get("ID", None)
                 new_id = None
 
-                # make_sure_id_is_unique
-                if not is_unique_id(obj, km_id):
+                # ensure_unique_id
+                if is_unique_id(obj, km_id) == False:
                     new_id = new_object_id()
                     obj.keymesh["ID"] = new_id
-                    print("ID CHANGED to: ", str(new_id))
 
                 for block in obj.keymesh.blocks:
                     if new_id != None:

--- a/functions/handler.py
+++ b/functions/handler.py
@@ -100,5 +100,8 @@ def append_keymesh(lapp_context):
                     obj.keymesh["ID"] = new_id
 
                 for block in obj.keymesh.blocks:
+                    data = block.block
+
+                    data.use_fake_user = True
                     if new_id != None:
-                        block.block.keymesh["ID"] = new_id
+                        data.keymesh["ID"] = new_id

--- a/functions/handler.py
+++ b/functions/handler.py
@@ -54,7 +54,6 @@ def update_keymesh(scene):
             obj.data.use_mirror_y = symmetry_y
             obj.data.use_mirror_z = symmetry_z
 
-
         # Update Active Index
         if bpy.context.active_object:
             scene = bpy.context.scene.keymesh
@@ -81,16 +80,18 @@ def append_keymesh(lapp_context):
     stage = lapp_context.process_stage # return: 'INIT' (for pre) and 'DONE' (for post)
 
     is_linking = True if 'LINK' in options else False
+    has_keymesh = False
 
     for item in items:
         type = item.id_type
         direct = False if 'INDIRECT_USAGE' not in item.import_info else True
         library = item.source_library
 
-        # Keymesh Object
+        # Detect Keymesh Object
         if type == 'OBJECT':
             obj = item.id
             if obj.keymesh.active:
+                has_keymesh = True
                 km_id = obj.keymesh.get("ID", None)
                 new_id = None
 
@@ -99,9 +100,18 @@ def append_keymesh(lapp_context):
                     new_id = new_object_id()
                     obj.keymesh["ID"] = new_id
 
+                # detect_keymesh_blocks
                 for block in obj.keymesh.blocks:
                     data = block.block
 
                     data.use_fake_user = True
                     if new_id != None:
                         data.keymesh["ID"] = new_id
+
+
+    # update_frame_handler
+    if has_keymesh:
+        """NOTE: `update_keymesh()` is not working because `obj.keymesh.get("ID")` is set to frame of original file"""
+        current_frame = bpy.context.scene.frame_current
+        bpy.context.scene.frame_set(current_frame + 1)
+        bpy.context.scene.frame_set(current_frame)

--- a/functions/handler.py
+++ b/functions/handler.py
@@ -1,4 +1,4 @@
-import bpy
+import bpy, os
 from .. import __package__ as base_package
 from .poll import is_keymesh_object
 from .timeline import get_keymesh_fcurve
@@ -95,7 +95,7 @@ def append_keymesh(lapp_context):
                 km_id = obj.keymesh.get("ID", None)
                 new_id = None
 
-                # ensure_unique_id
+                # Ensure Unique ID
                 if is_unique_id(obj, km_id) == False:
                     new_id = new_object_id()
                     obj.keymesh["ID"] = new_id
@@ -107,6 +107,20 @@ def append_keymesh(lapp_context):
                     data.use_fake_user = True
                     if new_id != None:
                         data.keymesh["ID"] = new_id
+
+                    # Make Thumbnails Relative
+                    """NOTE: Since thumbnails (StringProperty) are set to relative in library files, they're incorrect when imported"""
+                    """NOTE: this code gets absolute path for them and generates new path relative to receiving file"""
+                    if block.thumbnail != "":
+                        library_path = os.path.dirname(library.filepath)
+                        thumbnail_path = block.thumbnail.lstrip("/\\")
+                        abs_thumbnail_path = os.path.join(library_path, thumbnail_path)
+
+                        if os.path.splitdrive(abs_thumbnail_path)[0] != os.path.splitdrive(bpy.data.filepath)[0]:
+                            """Assign absolute path is current file is on different disk"""
+                            block.thumbnail = abs_thumbnail_path
+                        else:
+                            block.thumbnail = bpy.path.relpath(abs_thumbnail_path)
 
 
     # update_frame_handler

--- a/functions/object.py
+++ b/functions/object.py
@@ -17,6 +17,22 @@ def new_object_id():
     return id
 
 
+def is_unique_id(obj, id):
+    """Checks if any of the objects in the .blend file have same Keymesh ID as obj"""
+    """Used in link/append handlers to make sure objects don't have same ID"""
+
+    unique = True
+    for obj in bpy.data.objects:
+        if not obj.keymesh.active:
+            return
+        if obj.keymesh.get("ID", None):
+            if obj.keymesh.get("ID", None) == id:
+                unique = False
+                break
+    
+    return unique
+
+
 def get_next_keymesh_index(obj):
     """Get the appropriate index for the newly created/added Keymesh block"""
 

--- a/functions/object.py
+++ b/functions/object.py
@@ -21,16 +21,15 @@ def is_unique_id(obj, id):
     """Checks if any of the objects in the .blend file have same Keymesh ID as obj"""
     """Used in link/append handlers to make sure objects don't have same ID"""
 
-    unique = True
-    for obj in bpy.data.objects:
-        if not obj.keymesh.active:
-            return
-        if obj.keymesh.get("ID", None):
-            if obj.keymesh.get("ID", None) == id:
-                unique = False
-                break
-    
-    return unique
+    for ob in bpy.data.objects:
+        if ob == obj:
+            continue
+        if not ob.keymesh.active:
+            continue
+        if ob.keymesh.get("ID", None) == id:
+            return False
+
+    return True
 
 
 def get_next_keymesh_index(obj):


### PR DESCRIPTION
Blender developers implemented handlers for linking and appending in [/blender/pulls/128279](https://projects.blender.org/blender/blender/pulls/128279) based on my request in [/blender/issues/122357](https://projects.blender.org/blender/blender/issues/122357). This is the PR that deploys handlers for uses outlined in #5 and more.

- <ins>Ensure Unique ID:</ins> Function checks whether or not appended objects Keymesh ID is already occupied by other Keymesh objects in .blend file, and if it is, it sets new unique ID to appended object and its blocks.
- <ins>Reset fake user to Keymesh blocks</ins>
- <ins>Refresh timeline at the end</ins> to make sure correct block is displayed for current frame.
- <ins>Make thumbnail paths relative:</ins> Since `block.thumbnail` is made relative in library file when appending it doesn't point to correct file anymore. Function now first gets absolute path to the thumbnail, and then makes it relative to the receiving .blend file (or keeps it absolute if file is on different disk).
- <ins>Remove Keymesh properties on directly appended blocks:</ins> if object data, which is used as Keymesh block in the library file is appended remove `keymesh("ID")` and `keymesh("Data")` properties from it, because it's not gonna be used as Keymesh block in receiving file.
- <ins>Fix name collisions:</ins> If receiving scene already contained object data with same name as any of the Keymesh blocks, it would rename appended data, but `block.name` would remain the same. Function now checks if names match, and if not, renames `block.name` to object data name.