### PR TITLE
Frame Picker: Separate selection and keyframing

### DIFF
--- a/functions/handler.py
+++ b/functions/handler.py
@@ -56,18 +56,16 @@ def update_keymesh(scene):
 
         # Update Active Index
         if bpy.context.active_object:
-            scene = bpy.context.scene.keymesh
-            if scene.sync_with_timeline:
-                active_ui_index = obj.keymesh.blocks_active_index
+            active_ui_index = obj.keymesh.blocks_active_index
 
-                if active_ui_index is not None:
-                    active_block_index = obj.keymesh.blocks.find(obj.data.name)
+            if active_ui_index is not None:
+                active_block_index = obj.keymesh.blocks.find(obj.data.name)
 
-                    if (active_ui_index != active_block_index) and (active_block_index >= 0):
-                        if bpy.context.active_object.keymesh.grid_view:
-                            obj.keymesh.blocks_grid = str(active_block_index)
-                        else:
-                            obj.keymesh.blocks_active_index = int(active_block_index)
+                if (active_ui_index != active_block_index) and (active_block_index >= 0):
+                    if bpy.context.active_object.keymesh.grid_view:
+                        obj.keymesh.blocks_grid = str(active_block_index)
+                    else:
+                        obj.keymesh.blocks_active_index = int(active_block_index)
 
 
 

--- a/functions/handler.py
+++ b/functions/handler.py
@@ -24,8 +24,6 @@ def update_keymesh(scene):
         if fcurve.mute:
             continue
 
-        obj_keymesh_data = obj.keymesh["Keymesh Data"]
-
         # store_data_that_is_not_persistent
         if prefs.persistent_settings and obj.type == 'MESH':
             remesh_voxel_size = obj.data.remesh_voxel_size
@@ -36,15 +34,14 @@ def update_keymesh(scene):
 
         # Find Correct Keymesh Block for Object (with Same Data)
         correct_block = None
+        obj_keymesh_data = obj.keymesh["Keymesh Data"]
         for block in obj.keymesh.blocks:
-            block_keymesh_data = block.block.keymesh["Data"]
-            if block_keymesh_data != obj_keymesh_data:
-                continue
-            correct_block = block.block
+            if block.block.keymesh["Data"] == obj_keymesh_data:
+                correct_block = block.block
+                break
 
-        if not correct_block:
-            continue
-        obj.data = correct_block
+        if correct_block:
+            obj.data = correct_block
 
         # restore_inpersistent_data
         if prefs.persistent_settings and obj.type == 'MESH':
@@ -54,18 +51,19 @@ def update_keymesh(scene):
             obj.data.use_mirror_y = symmetry_y
             obj.data.use_mirror_z = symmetry_z
 
+
         # Update Active Index
-        if bpy.context.active_object:
-            active_ui_index = obj.keymesh.blocks_active_index
+        if obj == bpy.context.active_object:
+            """NOTE: UI updates aren't important for non-active objects because it's not visible anyway"""
+            ui_index = obj.keymesh.blocks_active_index
+            if ui_index is not None:
+                block_index = obj.keymesh.blocks.find(obj.data.name)
 
-            if active_ui_index is not None:
-                active_block_index = obj.keymesh.blocks.find(obj.data.name)
-
-                if (active_ui_index != active_block_index) and (active_block_index >= 0):
-                    if bpy.context.active_object.keymesh.grid_view:
-                        obj.keymesh.blocks_grid = str(active_block_index)
+                if (ui_index != block_index) and (block_index >= 0):
+                    if obj.keymesh.grid_view:
+                        obj.keymesh.blocks_grid = str(block_index)
                     else:
-                        obj.keymesh.blocks_active_index = int(active_block_index)
+                        obj.keymesh.blocks_active_index = int(block_index)
 
 
 

--- a/functions/object.py
+++ b/functions/object.py
@@ -150,21 +150,18 @@ def update_active_index(obj, index=None):
 def update_active_block_by_index(obj):
     """Get Keymesh block with UI index and assign it to active object"""
 
-    data_block = None
-    for i, block in enumerate(obj.keymesh.blocks):
-        if i == obj.keymesh.blocks_active_index:
-            data_block = block
-            break
+    index = int(obj.keymesh.blocks_active_index)
+    block = obj.keymesh.blocks[index].block
 
     # Assign Keymesh Block to Object
-    if data_block:
-        if obj.data.name != data_block.name:
+    if block:
+        if obj.data.name != block.name:
             data_type = obj_data_type(obj)
-            obj.data = data_type[data_block.name]
+            obj.data = data_type[block.name]
 
         # Update Static Object
         if obj.keymesh.animated == False:
-            obj.keymesh["Keymesh Data"] = data_block.block.keymesh.get("Data", None)
+            obj.keymesh["Keymesh Data"] = block.keymesh.get("Data", None)
 
 
 def convert_to_mesh(context, obj):

--- a/functions/object.py
+++ b/functions/object.py
@@ -153,14 +153,18 @@ def update_active_block_by_index(obj):
     data_block = None
     for i, block in enumerate(obj.keymesh.blocks):
         if i == obj.keymesh.blocks_active_index:
-            data_block = block.name
+            data_block = block
             break
 
     # Assign Keymesh Block to Object
     if data_block:
-        if obj.data.name != data_block:
+        if obj.data.name != data_block.name:
             data_type = obj_data_type(obj)
-            obj.data = data_type[data_block]
+            obj.data = data_type[data_block.name]
+
+        # Update Static Object
+        if obj.keymesh.animated == False:
+            obj.keymesh["Keymesh Data"] = data_block.block.keymesh.get("Data", None)
 
 
 def convert_to_mesh(context, obj):

--- a/functions/object.py
+++ b/functions/object.py
@@ -147,21 +147,20 @@ def update_active_index(obj, index=None):
     obj.keymesh.blocks_grid = str(index)
 
 
-def update_active_block_by_index(self, obj):
+def update_active_block_by_index(obj):
     """Get Keymesh block with UI index and assign it to active object"""
 
     data_block = None
     for i, block in enumerate(obj.keymesh.blocks):
-        if i == int(self.blocks_grid):
+        if i == obj.keymesh.blocks_active_index:
             data_block = block.name
             break
 
     # Assign Keymesh Block to Object
     if data_block:
-        data_type = obj_data_type(obj)
-        obj.data = data_type[data_block]
-
-    print("THIS HAPPENED for object: ", obj.name)
+        if obj.data.name != data_block:
+            data_type = obj_data_type(obj)
+            obj.data = data_type[data_block]
 
 
 def convert_to_mesh(context, obj):

--- a/functions/object.py
+++ b/functions/object.py
@@ -1,5 +1,5 @@
 import bpy, random
-from .poll import is_keymesh_object
+from .poll import is_keymesh_object, obj_data_type
 from .timeline import get_keymesh_fcurve, delete_empty_action
 from .. import __package__ as base_package
 
@@ -145,6 +145,23 @@ def update_active_index(obj, index=None):
         index = obj.keymesh.blocks.find(obj.data.name)
     obj.keymesh.blocks_active_index = int(index)
     obj.keymesh.blocks_grid = str(index)
+
+
+def update_active_block_by_index(self, obj):
+    """Get Keymesh block with UI index and assign it to active object"""
+
+    data_block = None
+    for i, block in enumerate(obj.keymesh.blocks):
+        if i == int(self.blocks_grid):
+            data_block = block.name
+            break
+
+    # Assign Keymesh Block to Object
+    if data_block:
+        data_type = obj_data_type(obj)
+        obj.data = data_type[data_block]
+
+    print("THIS HAPPENED for object: ", obj.name)
 
 
 def convert_to_mesh(context, obj):

--- a/operators/frame_picker.py
+++ b/operators/frame_picker.py
@@ -32,21 +32,21 @@ class OBJECT_OT_keymesh_pick_frame(bpy.types.Operator):
     def execute(self, context):
         scene = context.scene
         obj = context.active_object
-        data_type = obj_data_type(obj)
 
         # Assign Keymesh Block to Object
+        data_type = obj_data_type(obj)
         obj.data = data_type[self.block]
         update_active_index(obj)
 
         # account_for_non_animated_Keymesh_objects (properly_assign_block_by_changing_object_keymesh_data_as_well)
         block_keymesh_data = obj.data.keymesh.get("Data")
-        if scene.keymesh.insert_on_selection == False and obj.keymesh.animated == False:
+        if scene.keymesh.keyframe_on_selection == False and obj.keymesh.animated == False:
             obj.keymesh["Keymesh Data"] = int(block_keymesh_data)
 
 
         # Keyframe Block
         if obj in context.editable_objects:
-            if scene.keymesh.insert_on_selection:
+            if scene.keymesh.keyframe_on_selection:
                 # create_action_if_object_isn't_animated
                 if not obj.keymesh.animated:
                     new_action = bpy.data.actions.new(obj.name + "Action")

--- a/operators/frame_picker.py
+++ b/operators/frame_picker.py
@@ -38,30 +38,24 @@ class OBJECT_OT_keymesh_pick_frame(bpy.types.Operator):
         obj.data = data_type[self.block]
         update_active_index(obj)
 
-        # account_for_non_animated_Keymesh_objects (properly_assign_block_by_changing_object_keymesh_data_as_well)
-        block_keymesh_data = obj.data.keymesh.get("Data")
-        if scene.keymesh.keyframe_on_selection == False and obj.keymesh.animated == False:
-            obj.keymesh["Keymesh Data"] = int(block_keymesh_data)
-
-
         # Keyframe Block
+        block_keymesh_data = obj.data.keymesh.get("Data")
         if obj in context.editable_objects:
-            if scene.keymesh.keyframe_on_selection:
-                # create_action_if_object_isn't_animated
-                if not obj.keymesh.animated:
-                    new_action = bpy.data.actions.new(obj.name + "Action")
-                    obj.animation_data_create()
-                    obj.animation_data.action = new_action
-                    obj.keymesh.animated = True
+            # create_action_if_object_isn't_animated
+            if not obj.keymesh.animated:
+                new_action = bpy.data.actions.new(obj.name + "Action")
+                obj.animation_data_create()
+                obj.animation_data.action = new_action
+                obj.keymesh.animated = True
 
-                action = obj.animation_data.action
-                if action:
-                    if action.library is None:
-                        insert_keyframe(obj, scene.frame_current, block_keymesh_data)
-                    else:
-                        self.report({'INFO'}, "You cannot animate in library overriden action. Create local one")
-                else:
+            action = obj.animation_data.action
+            if action:
+                if action.library is None:
                     insert_keyframe(obj, scene.frame_current, block_keymesh_data)
+                else:
+                    self.report({'INFO'}, "You cannot animate in library overriden action. Create local one")
+            else:
+                insert_keyframe(obj, scene.frame_current, block_keymesh_data)
 
         return {'FINISHED'}
 

--- a/operators/join_extract.py
+++ b/operators/join_extract.py
@@ -137,23 +137,20 @@ class OBJECT_OT_keymesh_extract(bpy.types.Operator):
             context.view_layer.active_layer_collection.collection.objects.unlink(obj)
         else:
             # set_new_active_block
-            if block == initial_data:
-                if obj.keymesh.animated:
-                    """NOTE: Refreshing timeline for same reason as in 'object.remove_keymesh_block' operator."""
-                    current_frame = context.scene.frame_current
-                    context.scene.frame_set(current_frame + 1)
-                    context.scene.frame_set(current_frame)
-                    update_active_index(obj)
-                else:
-                    # make_previous_block_new_obj.data_for_static_keymesh_objects
-                    previous_index = index - 1 if index - 1 > -1 else 0
-                    update_active_index(obj, index=previous_index)
-
-                    previous_block = obj.keymesh.blocks[obj.keymesh.blocks_active_index].block
-                    obj.data = previous_block
-                    obj.keymesh["Keymesh Data"] = previous_block.keymesh["Data"]
-            else:
+            if obj.keymesh.animated:
+                """NOTE: Refreshing timeline to update objects "Keymesh Data" property"""
+                current_frame = context.scene.frame_current
+                context.scene.frame_set(current_frame + 1)
+                context.scene.frame_set(current_frame)
                 update_active_index(obj)
+            else:
+                # make_previous_block_new_obj.data_for_static_keymesh_objects
+                previous_index = index - 1 if index - 1 > -1 else 0
+                update_active_index(obj, index=previous_index)
+
+                previous_block = obj.keymesh.blocks[obj.keymesh.blocks_active_index].block
+                obj.data = previous_block
+                obj.keymesh["Keymesh Data"] = previous_block.keymesh["Data"]
 
         # make_new_object_active
         for ob in context.view_layer.objects:

--- a/operators/purge_unused_data.py
+++ b/operators/purge_unused_data.py
@@ -139,7 +139,6 @@ class OBJECT_OT_keymesh_remove(bpy.types.Operator):
             bpy.data.objects.remove(obj)
         else:
             initial_index = obj.keymesh.blocks_active_index
-            initial_data = obj.data
 
             # get_active_block
             if (initial_index is None) or (initial_index > len(obj.keymesh.blocks) - 1):
@@ -149,20 +148,14 @@ class OBJECT_OT_keymesh_remove(bpy.types.Operator):
             # remove_from_block_registry
             remove_block(obj, block)
 
+
             # make_previous_block_active
             previous_block_index = initial_index - 1 if initial_index - 1 > -1 else 0
-            if obj.keymesh.animated:
-                """NOTE: Scrubbing timeline makes sure that correct object data is asigned based on previous found keyframe."""
-                """NOTE: Without this whole object is deleted because Blender thinks it doesn't have object data anymore."""
-                current_frame = context.scene.frame_current
-                context.scene.frame_set(current_frame + 1)
-                context.scene.frame_set(current_frame)
-            else:
-                if block == initial_data:
-                    # make_previous_block_new_obj.data_for_static_keymesh_objects
-                    previous_block = obj.keymesh.blocks[previous_block_index].block
-                    obj.data = previous_block
-                    obj.keymesh["Keymesh Data"] = previous_block.keymesh["Data"]
+            if obj.keymesh.animated == False:
+                # make_previous_block_new_obj.data_for_static_keymesh_objects
+                previous_block = obj.keymesh.blocks[previous_block_index].block
+                obj.data = previous_block
+                obj.keymesh["Keymesh Data"] = previous_block.keymesh["Data"]
 
             update_active_index(obj, index=previous_block_index)
 

--- a/properties.py
+++ b/properties.py
@@ -21,7 +21,7 @@ def keymesh_blocks_grid_update(self, context):
 
     if self.id_data.keymesh.grid_view:
         self.blocks_active_index = int(self.blocks_grid)
-        update_active_block_by_index(self, self.id_data)
+        update_active_block_by_index(self.id_data)
 
 
 def keymesh_blocks_list_update(self, context):
@@ -31,7 +31,7 @@ def keymesh_blocks_list_update(self, context):
     if self.id_data.keymesh.grid_view == False:
         if self.blocks_active_index >= 0:
             self.blocks_grid = str(self.blocks_active_index)
-            update_active_block_by_index(self, self.id_data)
+            update_active_block_by_index(self.id_data)
 
 
 def thumbnails_render_offer(self, context):

--- a/properties.py
+++ b/properties.py
@@ -1,5 +1,5 @@
 import bpy
-from .functions.poll import obj_data_type
+from .functions.object import update_active_block_by_index
 from .functions.thumbnail import keymesh_blocks_enum_items, get_missing_thumbnails
 
 
@@ -19,31 +19,19 @@ def keymesh_blocks_grid_update(self, context):
     """Make active EnumProperty item active Keymesh block."""
     """NOTE: To make this work all enum_item id names should be str(i)."""
 
-    if context.active_object:
-        if context.active_object.keymesh.grid_view:
-            self.blocks_active_index = int(self.blocks_grid)
-
-            data_block = None
-            for i, block in enumerate(context.active_object.keymesh.blocks):
-                if i == int(self.blocks_grid):
-                    data_block = block.name
-                    break
-
-            # Assign Keymesh Block to Object
-            if data_block:
-                obj = context.active_object
-                data_type = obj_data_type(obj)
-                obj.data = data_type[data_block]
+    if self.id_data.keymesh.grid_view:
+        self.blocks_active_index = int(self.blocks_grid)
+        update_active_block_by_index(self, self.id_data)
 
 
 def keymesh_blocks_list_update(self, context):
     """Set blocks_active_index from active blocks_grid EnumProperty item."""
     """NOTE: To make this work all enum_item id names should be str(i)."""
 
-    if context.active_object:
-        if context.active_object.keymesh.grid_view == False:
-            if self.blocks_active_index >= 0:
-                self.blocks_grid = str(self.blocks_active_index)
+    if self.id_data.keymesh.grid_view == False:
+        if self.blocks_active_index >= 0:
+            self.blocks_grid = str(self.blocks_active_index)
+            update_active_block_by_index(self, self.id_data)
 
 
 def thumbnails_render_offer(self, context):

--- a/properties.py
+++ b/properties.py
@@ -1,4 +1,5 @@
 import bpy
+from .functions.poll import obj_data_type
 from .functions.thumbnail import keymesh_blocks_enum_items, get_missing_thumbnails
 
 
@@ -14,7 +15,7 @@ def update_block_name(self, context):
             self.name = self.block.name
 
 
-def keymesh_blocks_enum_update(self, context):
+def keymesh_blocks_grid_update(self, context):
     """Make active EnumProperty item active Keymesh block."""
     """NOTE: To make this work all enum_item id names should be str(i)."""
 
@@ -22,8 +23,20 @@ def keymesh_blocks_enum_update(self, context):
         if context.active_object.keymesh.grid_view:
             self.blocks_active_index = int(self.blocks_grid)
 
+            data_block = None
+            for i, block in enumerate(context.active_object.keymesh.blocks):
+                if i == int(self.blocks_grid):
+                    data_block = block.name
+                    break
 
-def keymesh_blocks_coll_update(self, context):
+            # Assign Keymesh Block to Object
+            if data_block:
+                obj = context.active_object
+                data_type = obj_data_type(obj)
+                obj.data = data_type[data_block]
+
+
+def keymesh_blocks_list_update(self, context):
     """Set blocks_active_index from active blocks_grid EnumProperty item."""
     """NOTE: To make this work all enum_item id names should be str(i)."""
 
@@ -95,12 +108,12 @@ class OBJECT_PG_keymesh(bpy.types.PropertyGroup):
         items = keymesh_blocks_enum_items,
         options = {'HIDDEN', 'LIBRARY_EDITABLE'},
         override = {"LIBRARY_OVERRIDABLE"},
-        update = keymesh_blocks_enum_update,
+        update = keymesh_blocks_grid_update,
     )
     blocks_active_index: bpy.props.IntProperty(
         name = "Active Block Index",
         options = set(),
-        update = keymesh_blocks_coll_update,
+        update = keymesh_blocks_list_update,
         default = -1,
     )
 
@@ -147,15 +160,9 @@ class SCENE_PG_keymesh(bpy.types.PropertyGroup):
         options = {'HIDDEN'},
         default = True,
     )
-    insert_on_selection: bpy.props.BoolProperty(
+    keyframe_on_selection: bpy.props.BoolProperty(
         name = "Keyframe Keymesh Blocks After Selection",
-        description = "Automatically insert keyframe on current frame for Keymesh block when selecting it.",
-        options = {'HIDDEN'},
-        default = True,
-    )
-    sync_with_timeline: bpy.props.BoolProperty(
-        name = "Synchronize with Timeline",
-        description = "Make active Keymesh block also active item in frame picker UI when scrubbing timeline",
+        description = "Automatically insert keyframe on current frame for Keymesh block when selecting it",
         options = {'HIDDEN'},
         default = True,
     )

--- a/properties.py
+++ b/properties.py
@@ -148,12 +148,6 @@ class SCENE_PG_keymesh(bpy.types.PropertyGroup):
         options = {'HIDDEN'},
         default = True,
     )
-    keyframe_on_selection: bpy.props.BoolProperty(
-        name = "Keyframe Keymesh Blocks After Selection",
-        description = "Automatically insert keyframe on current frame for Keymesh block when selecting it",
-        options = {'HIDDEN'},
-        default = True,
-    )
 
     def update_properties_from_preferences(self):
         prefs = bpy.context.preferences.addons[__package__].preferences

--- a/properties.py
+++ b/properties.py
@@ -19,19 +19,21 @@ def keymesh_blocks_grid_update(self, context):
     """Make active EnumProperty item active Keymesh block."""
     """NOTE: To make this work all enum_item id names should be str(i)."""
 
-    if self.id_data.keymesh.grid_view:
+    obj = self.id_data
+    if obj.keymesh.grid_view:
         self.blocks_active_index = int(self.blocks_grid)
-        update_active_block_by_index(self.id_data)
+        update_active_block_by_index(obj)
 
 
 def keymesh_blocks_list_update(self, context):
     """Set blocks_active_index from active blocks_grid EnumProperty item."""
     """NOTE: To make this work all enum_item id names should be str(i)."""
 
-    if self.id_data.keymesh.grid_view == False:
+    obj = self.id_data
+    if obj.keymesh.grid_view == False:
         if self.blocks_active_index >= 0:
             self.blocks_grid = str(self.blocks_active_index)
-            update_active_block_by_index(self.id_data)
+            update_active_block_by_index(obj)
 
 
 def thumbnails_render_offer(self, context):

--- a/ui.py
+++ b/ui.py
@@ -5,25 +5,20 @@ from .functions.timeline import get_keymesh_fcurve, keymesh_block_usage_count
 
 #### ------------------------------ FUNCTIONS ------------------------------ ####
 
-def get_block_icon(context, obj, block):
+def get_block_icon(obj, block):
     """Returns correct icon for Keymesh block based on scene properties, object state, and blocks status"""
 
-    action = obj.animation_data.action if obj.animation_data else None
     obj_keymesh_data = obj.keymesh.get("Keymesh Data")
     block_keymesh_data = block.block.keymesh.get("Data")
 
-    if obj in context.editable_objects and (action and action.library is None):
-        if block_keymesh_data == obj_keymesh_data:
-            select_icon = 'RADIOBUT_ON'
-        else:
-            select_icon = 'RADIOBUT_OFF'
+    if (block_keymesh_data == obj.data.keymesh.get("Data")
+        and block_keymesh_data != obj_keymesh_data
+        and obj.keymesh.animated):
+        select_icon = 'VIEWZOOM'
+    elif block_keymesh_data == obj_keymesh_data:
+        select_icon = 'RADIOBUT_ON'
     else:
-        if block_keymesh_data == obj.data.keymesh.get("Data") and block_keymesh_data != obj_keymesh_data:
-            select_icon = 'VIEWZOOM'
-        elif block_keymesh_data == obj_keymesh_data:
-            select_icon = 'PINNED'
-        else:
-            select_icon = 'UNPINNED'
+        select_icon = 'RADIOBUT_OFF'
 
     return select_icon
 
@@ -146,7 +141,7 @@ class VIEW3D_PT_keymesh_frame_picker(bpy.types.Panel):
             row.alignment = 'EXPAND'
 
             row.operator("object.keymesh_block_active_set", text="Previous", icon='BACK').direction='PREVIOUS'
-            row.operator("object.keymesh_pick_frame", text="", icon=get_block_icon(context, obj, active_block)).block = active_block.name
+            row.operator("object.keymesh_pick_frame", text="", icon=get_block_icon(obj, active_block)).block = active_block.name
             row.operator("object.keymesh_block_active_set", text="Next", icon='FORWARD').direction='NEXT'
 
 
@@ -217,7 +212,7 @@ class VIEW3D_UL_keymesh_blocks(bpy.types.UIList):
         row = col.row(align=True)
 
         # Name
-        row.operator("object.keymesh_pick_frame", text="", icon=get_block_icon(context, obj, item)).block = item.name
+        row.operator("object.keymesh_pick_frame", text="", icon=get_block_icon(obj, item), emboss=False).block = item.name
         row.prop(item, "name", text="", emboss=False)
 
         # Usage Count

--- a/ui.py
+++ b/ui.py
@@ -128,6 +128,7 @@ class VIEW3D_PT_keymesh_frame_picker(bpy.types.Panel):
             row = col.row(align=True)
             row.prop(active_block, "thumbnail", text="")
             row.operator("object.keymesh_thumbnails_refresh", text="", icon='FILE_REFRESH')
+            row.active = False
 
             # buttons
             col = layout.column()

--- a/ui.py
+++ b/ui.py
@@ -12,7 +12,7 @@ def get_block_icon(context, obj, block):
     obj_keymesh_data = obj.keymesh.get("Keymesh Data")
     block_keymesh_data = block.block.keymesh.get("Data")
 
-    if context.scene.keymesh.keyframe_on_selection and obj in context.editable_objects and (action and action.library is None):
+    if obj in context.editable_objects and (action and action.library is None):
         if block_keymesh_data == obj_keymesh_data:
             select_icon = 'RADIOBUT_ON'
         else:
@@ -118,12 +118,6 @@ class VIEW3D_PT_keymesh_frame_picker(bpy.types.Panel):
             col.separator()
             col.operator("object.keymesh_block_move", text="", icon='TRIA_UP').direction='UP'
             col.operator("object.keymesh_block_move", text="", icon='TRIA_DOWN').direction='DOWN'
-
-            # properties
-            col = layout.column(align=True)
-            col.prop(scene, "keyframe_on_selection", text="Keyframe on Selection")
-            if not obj in context.editable_objects:
-                col.enabled = False
 
 
         # Grid View

--- a/ui.py
+++ b/ui.py
@@ -11,11 +11,7 @@ def get_block_icon(obj, block):
     obj_keymesh_data = obj.keymesh.get("Keymesh Data")
     block_keymesh_data = block.block.keymesh.get("Data")
 
-    if (block_keymesh_data == obj.data.keymesh.get("Data")
-        and block_keymesh_data != obj_keymesh_data
-        and obj.keymesh.animated):
-        select_icon = 'VIEWZOOM'
-    elif block_keymesh_data == obj_keymesh_data:
+    if block_keymesh_data == obj_keymesh_data:
         select_icon = 'RADIOBUT_ON'
     else:
         select_icon = 'RADIOBUT_OFF'

--- a/ui.py
+++ b/ui.py
@@ -3,6 +3,32 @@ from .functions.poll import is_linked, is_keymesh_object
 from .functions.timeline import get_keymesh_fcurve, keymesh_block_usage_count
 
 
+#### ------------------------------ FUNCTIONS ------------------------------ ####
+
+def get_block_icon(context, obj, block):
+    """Returns correct icon for Keymesh block based on scene properties, object state, and blocks status"""
+
+    action = obj.animation_data.action if obj.animation_data else None
+    obj_keymesh_data = obj.keymesh.get("Keymesh Data")
+    block_keymesh_data = block.block.keymesh.get("Data")
+
+    if context.scene.keymesh.keyframe_on_selection and obj in context.editable_objects and (action and action.library is None):
+        if block_keymesh_data == obj_keymesh_data:
+            select_icon = 'RADIOBUT_ON'
+        else:
+            select_icon = 'RADIOBUT_OFF'
+    else:
+        if block_keymesh_data == obj.data.keymesh.get("Data") and block_keymesh_data != obj_keymesh_data:
+            select_icon = 'VIEWZOOM'
+        elif block_keymesh_data == obj_keymesh_data:
+            select_icon = 'PINNED'
+        else:
+            select_icon = 'UNPINNED'
+
+    return select_icon
+
+
+
 #### ------------------------------ PANELS ------------------------------ ####
 
 class VIEW3D_PT_keymesh(bpy.types.Panel):
@@ -95,7 +121,7 @@ class VIEW3D_PT_keymesh_frame_picker(bpy.types.Panel):
 
             # properties
             col = layout.column(align=True)
-            col.prop(scene, "insert_on_selection", text="Keyframe on Selection")
+            col.prop(scene, "keyframe_on_selection", text="Keyframe on Selection")
             if not obj in context.editable_objects:
                 col.enabled = False
 
@@ -125,38 +151,9 @@ class VIEW3D_PT_keymesh_frame_picker(bpy.types.Panel):
             row.scale_y = 1.5
             row.alignment = 'EXPAND'
 
-            # get_keyframe_icon_based_on_animation_state
-            fcurve = get_keymesh_fcurve(obj)
-            is_keyframed = False
-            is_active = False
-            if fcurve:
-                for keyframe in fcurve.keyframe_points:
-                    if keyframe.co.x == context.scene.frame_current:
-                        is_keyframed = True
-                        if int(keyframe.co.y) == obj.keymesh.blocks[int(obj.keymesh.blocks_grid)].block.keymesh["Data"]:
-                            is_active = True
-                            break
-
-            if obj not in context.editable_objects:
-                if obj.keymesh.blocks[active_index].block != obj.data:
-                    icon = 'VIEWZOOM'
-                else:
-                    icon = 'PINNED'
-            else:
-                if is_active:
-                    icon = 'DECORATE_KEYFRAME'
-                else:
-                    if is_keyframed:
-                        icon = 'DECORATE_OVERRIDE'
-                    else:
-                        icon = 'DECORATE_ANIMATE'
-
             row.operator("object.keymesh_block_active_set", text="Previous", icon='BACK').direction='PREVIOUS'
-            row.operator("object.keymesh_pick_frame", text="", icon=icon).block = active_block.name
+            row.operator("object.keymesh_pick_frame", text="", icon=get_block_icon(context, obj, active_block)).block = active_block.name
             row.operator("object.keymesh_block_active_set", text="Next", icon='FORWARD').direction='NEXT'
-
-            col = layout.column(align=True)
-            col.prop(scene, "sync_with_timeline", text="Synchronize Active with Timeline")
 
 
 class VIEW3D_PT_keymesh_tools(bpy.types.Panel):
@@ -220,29 +217,14 @@ class VIEW3D_UL_keymesh_blocks(bpy.types.UIList):
 
     def draw_item(self, context, layout, data, item, icon, active_data, active_property, index):
         obj = context.active_object
-        action = obj.animation_data.action if obj.animation_data else None
-
-        obj_keymesh_data = obj.keymesh.get("Keymesh Data")
-        block_keymesh_data = item.block.keymesh.get("Data")
         usage_count, __ = keymesh_block_usage_count(obj, item.block)
 
         col = layout.column(align=True)
         row = col.row(align=True)
 
-        # insert_button_icon
-        if context.scene.keymesh.insert_on_selection and obj in context.editable_objects and (action and action.library is None):
-            select_icon = 'PINNED' if block_keymesh_data == obj_keymesh_data else 'UNPINNED'
-        else:
-            if block_keymesh_data == obj.data.keymesh.get("Data") and block_keymesh_data != obj_keymesh_data:
-                select_icon = 'VIEWZOOM'
-            elif block_keymesh_data == obj_keymesh_data:
-                select_icon = 'PINNED'
-            else:
-                select_icon = 'UNPINNED'
-
         # Name
-        row.operator("object.keymesh_pick_frame", text="", icon=select_icon).block = item.name
-        row.prop(item, "name", text="", emboss=False,)
+        row.operator("object.keymesh_pick_frame", text="", icon=get_block_icon(context, obj, item)).block = item.name
+        row.prop(item, "name", text="", emboss=False)
 
         # Usage Count
         col = layout.column(align=True)


### PR DESCRIPTION
Based on #14 and aimed to solve the problem described there, but the design has been modified. The introduction of grid view and the "Synchronize with Timeline" feature that came with it made things more clear about what UI/UX should be. Also, there is now a need to align behaviors of list view and grid view and both of them should be intuitive.

The biggest problem now is that there are basically two selections in frame picker:
- Selecting item in list or grid, which only updates active index.
- Making block active object data (which sometimes comes with inserting keyframes, if "Keyframe no Selection" is on, but if it's off, it's impossible to keyframe)

Grid view had the limitation that you can't do both (assign & keyframe) with selection, and also there is only one selection there, so if we want the assignment to happen on selection we should combine two selections into one, and therefore make keyframing separate step outside selection.

After some testing, this behavior feels very nice, and would be good to replicate in list view as well. It also makes working with static Keymesh objects much more natural, because there is no need to disable property beforehand.

---

New behavior in nutshell:
- Selection: selecting item in UI list and making that block active object data.
- Keyframing: button in the UI to keyframe active object data (of course if keyframing non-selected item it also changes selection).

---

Other Changes:
-
- "Keyframe on Selection" button is removed, since there is no need for it anymore (frame picker operator always keyframes now).
- Icons in UI have been changed: they're not either empty circle (inactive) or filled (active). They're also not embossed to make it look cleaner.
- Regression: It's now impossible to preview block on library-overriden objects because active index property isn't overridable (because of color overlay issues). I'll think of solutions to this in the future.

---

Implementation Details:
- Since `update_keymesh()` handler updates active index it caused object data to be assigned twice: once in handler and once by property update. I'm avoiding this now by checking if data is already assigned.
- Rename `keymesh_blocks_coll_update` to "list_update" and `keymesh_blocks_enum_update` to "grid_update". This way it's easier to remember which is which.